### PR TITLE
feat: voice input with iOS 26 SpeechAnalyzer + edge glow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 
 # Xcode
 build/
+build-device/
+build-sim/
+ios/build-device/
+ios/build-sim/
 DerivedData/
 *.xcworkspace/xcuserdata/
 *.xcodeproj/xcuserdata/

--- a/ios/Nod.xcodeproj/project.pbxproj
+++ b/ios/Nod.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		10533DEC2A85635650C1859F /* MLXEngineClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495EE64172900DB2BC77D01B /* MLXEngineClient.swift */; };
 		118A13A5160E568B829AA1C0 /* ExtractedEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC922C8DEBEDEA243AF03846 /* ExtractedEntity.swift */; };
 		192E639D634F41A1DAEEC035 /* EntityExtractorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3F0CEBCAA938ADC34A73BD /* EntityExtractorService.swift */; };
+		1FBC0CECC5A173C3B38AFE79 /* DictationRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222263F4E36038A02EDE3442 /* DictationRecognizer.swift */; };
 		2402546061ADBA7D14B734A8 /* LaunchCrashBreaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 760F42DE20FF786A995C7621 /* LaunchCrashBreaker.swift */; };
 		2484EA93E6A4F4DC7305E7BE /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = FD58A9CC136146214D82403C /* GRDB */; };
 		24D408F3CA747F829DE44292 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F8BEB5AAF0BA2824DE66A5 /* SplashView.swift */; };
@@ -54,6 +55,7 @@
 		0D5DAEB03E40D203EEAD3708 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		114CF100E130E7C854FBB3BD /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		1A6F4141A334B9AFB3C05FBD /* EntityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityStore.swift; sourceTree = "<group>"; };
+		222263F4E36038A02EDE3442 /* DictationRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationRecognizer.swift; sourceTree = "<group>"; };
 		2281B1004AD6016FE4C8E3E1 /* FoundationModelsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationModelsClient.swift; sourceTree = "<group>"; };
 		2A403C8B5DDD2D7732FE7942 /* AppLockManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockManager.swift; sourceTree = "<group>"; };
 		30B89F2E8BF769A02D679773 /* PersonalizationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalizationStore.swift; sourceTree = "<group>"; };
@@ -153,6 +155,7 @@
 		41C8C3B2952D77AA18801C9E /* Inference */ = {
 			isa = PBXGroup;
 			children = (
+				222263F4E36038A02EDE3442 /* DictationRecognizer.swift */,
 				964ADD3303489CFCB3C4EF5D /* DownloadEvent.swift */,
 				5EF1D28D4CE6A1E6F644BF24 /* DownloadMetrics.swift */,
 				71720E33D89D0A92B33AD8AB /* DownloadTuning.swift */,
@@ -305,6 +308,7 @@
 				C24E2CCA2BCF01FB3AD383D9 /* AppLockOverlay.swift in Sources */,
 				36209BB2C752B19E2900045C /* ChatView.swift in Sources */,
 				AA00073895727FB4A2805062 /* ConversationStore.swift in Sources */,
+				1FBC0CECC5A173C3B38AFE79 /* DictationRecognizer.swift in Sources */,
 				F5A6DE494F786A55459B30F4 /* DownloadEvent.swift in Sources */,
 				771A5D99B8B6FB6CCF6E0FE3 /* DownloadMetrics.swift in Sources */,
 				0CA4A1858373C7DC8EE573C4 /* DownloadTuning.swift in Sources */,

--- a/ios/Nod.xcodeproj/xcshareddata/xcschemes/Nod.xcscheme
+++ b/ios/Nod.xcodeproj/xcshareddata/xcschemes/Nod.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1430"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -26,7 +27,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,6 +40,8 @@
       </MacroExpansion>
       <Testables>
       </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -59,6 +63,8 @@
             ReferencedContainer = "container:Nod.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -76,6 +82,8 @@
             ReferencedContainer = "container:Nod.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/ios/Nod/Inference/DictationRecognizer.swift
+++ b/ios/Nod/Inference/DictationRecognizer.swift
@@ -1,0 +1,554 @@
+// DictationRecognizer.swift
+// iOS 26 Speech-to-text using Apple's new SpeechAnalyzer + SpeechTranscriber.
+//
+// Why this rewrite (from SFSpeechRecognizer): the previous version made
+// the class @MainActor, so sync calls like AVAudioSession.setActive,
+// engine.prepare, and engine.start blocked the main thread. UI froze.
+// See https://useyourloaf.com/blog/swiftui-tasks-blocking-the-mainactor/
+//
+// Architecture:
+//   1. Class is @MainActor for SwiftUI state updates via @Published.
+//   2. Heavy audio/engine setup runs inside `Task.detached` so it
+//      truly leaves the main actor. The detached task owns the
+//      setup work; it hops back to main actor only for @Published
+//      state mutations.
+//   3. Audio resources (engine, transcriber, analyzer, continuation)
+//      are stored with `nonisolated(unsafe)` because they are
+//      reference-type singletons touched serially from setup and
+//      teardown paths. Safe in practice, ugly but clear.
+//   4. SpeechAnalyzer + SpeechTranscriber replaces SFSpeechRecognizer.
+//      Results come via `transcriber.results` AsyncSequence, which is
+//      designed for Swift concurrency from the ground up.
+//
+// Public API preserved so ChatView doesn't need rewiring:
+//   state, isUnavailableForSession, lastFinalText, start(), commit(),
+//   cancel().
+
+import AVFoundation
+import Combine
+import Foundation
+import OSLog
+import Speech
+
+// AVAudioPCMBuffer doesn't declare Sendable, but Apple's sample code
+// for SpeechAnalyzer crosses it across actor boundaries via AsyncStream.
+// Retroactive conformance at file scope is the canonical workaround.
+// PCM buffers from an input tap are immutable once captured, so there's
+// no actual unsafe aliasing.
+extension AVAudioPCMBuffer: @unchecked @retroactive Sendable {}
+
+// MARK: - Nonisolated permission helpers
+//
+// File-scope nonisolated so the Obj-C completion callback (which iOS
+// fires on a background queue) doesn't trip Swift 6's main-actor
+// isolation check. Previously these were inline inside start() and
+// crashed the app via SIGTRAP — the fix is to keep them at file scope.
+
+private func requestSpeechAuthorization() async -> SFSpeechRecognizerAuthorizationStatus {
+    await withCheckedContinuation { (continuation: CheckedContinuation<SFSpeechRecognizerAuthorizationStatus, Never>) in
+        SFSpeechRecognizer.requestAuthorization { status in
+            continuation.resume(returning: status)
+        }
+    }
+}
+
+private func requestMicrophonePermission() async -> Bool {
+    await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+        AVAudioApplication.requestRecordPermission { granted in
+            continuation.resume(returning: granted)
+        }
+    }
+}
+
+@MainActor
+final class DictationRecognizer: ObservableObject {
+
+    // MARK: - Public state
+
+    enum State: Equatable {
+        case idle
+        case requestingPermission
+        case listening
+        case committed(final: String)
+        case unavailable(UnavailableReason)
+    }
+
+    // Simplified from earlier. Previously State.listening carried
+    // `partial: String` and `silenceProgress: Double`. Every partial
+    // result and every 33ms progress tick mutated @Published state,
+    // firing objectWillChange, which re-rendered ChatView's entire
+    // body on every tick. Main actor saturated → app appeared frozen
+    // (taps queued but never processed). Now partial text + silence
+    // progress are tracked in private vars (below) that ChatView
+    // does NOT observe. @Published `state` only changes on true
+    // transitions (idle → listening → committed → idle), so ChatView
+    // re-renders a handful of times per recording session instead of
+    // hundreds per second.
+
+    enum UnavailableReason: Equatable {
+        case permissionDenied
+        case recognizerUnavailable
+        case audioEngineFailed
+    }
+
+    @Published private(set) var state: State = .idle
+    @Published private(set) var isUnavailableForSession = false
+    private(set) var lastFinalText: String = ""
+
+    /// Latest partial transcript. Updated every time the transcriber
+    /// emits a non-final result. NOT @Published — ChatView doesn't
+    /// observe it, so updates don't trigger ChatView re-renders.
+    private var currentPartial: String = ""
+
+    // MARK: - Private state
+
+    private let log = Logger(subsystem: "app.usenod.nod", category: "voice")
+
+    // Audio resources. `nonisolated(unsafe)` because:
+    //   - AVAudioEngine/SpeechAnalyzer/SpeechTranscriber are classes
+    //     (reference types).
+    //   - They are accessed from the @MainActor-isolated class AND
+    //     from the detached setup/teardown/analyze tasks.
+    //   - Access is serialized via the state machine: we set these
+    //     during setup, read them in teardown; no concurrent writes.
+    nonisolated(unsafe) private var engine: AVAudioEngine?
+    nonisolated(unsafe) private var transcriber: SpeechTranscriber?
+    nonisolated(unsafe) private var analyzer: SpeechAnalyzer?
+    nonisolated(unsafe) private var audioContinuation: AsyncStream<AnalyzerInput>.Continuation?
+
+    // Tasks — main actor
+    private var silenceTask: Task<Void, Never>?
+    private var resultsTask: Task<Void, Never>?
+    private var analyzeTask: Task<Void, Never>?
+    private var finalizeTask: Task<Void, Never>?
+
+    private var audioSessionActive = false
+    private var tapInstalled = false
+    private var startGeneration: Int = 0
+    /// Set true when commit() begins finalization. Prevents silence
+    /// timer + user tap from BOTH triggering commit() and racing two
+    /// finalize sequences against the same analyzer.
+    private var isFinalizing: Bool = false
+
+    private let silenceTotal: TimeInterval = 2.5
+
+    init() {}
+
+    // MARK: - Public API
+
+    func start() async {
+        if case .listening = state { return }
+
+        startGeneration &+= 1
+        let gen = startGeneration
+        // Clear any stale transcript from a previous session so
+        // ChatView can't re-insert it if this session fails before
+        // committing.
+        lastFinalText = ""
+        isFinalizing = false
+        state = .requestingPermission
+
+        // Step 1 — Speech recognition permission.
+        let speechStatus = await requestSpeechAuthorization()
+        guard gen == startGeneration else { return }
+        guard speechStatus == .authorized else {
+            state = .unavailable(.permissionDenied)
+            return
+        }
+
+        // Step 2 — Mic permission.
+        let micGranted = await requestMicrophonePermission()
+        guard gen == startGeneration else { return }
+        guard micGranted else {
+            state = .unavailable(.permissionDenied)
+            return
+        }
+
+        // Step 3 — Locale support for SpeechTranscriber.
+        //
+        // User's system locale can include regional subdivisions (e.g.
+        // "en_US@rg=inzzzz" for a US-English speaker in India).
+        // SpeechTranscriber.supportedLocales returns base locales like
+        // "en-US" — exact BCP-47 match fails. Match on language code
+        // first, then region as a tiebreaker, so the regional override
+        // doesn't exclude a perfectly-supported language.
+        let locale = Locale.current
+        let supported = await SpeechTranscriber.supportedLocales
+        let userLang = locale.language.languageCode?.identifier
+        let userRegion = locale.language.region?.identifier
+
+        // Best match: same language + same region (e.g. en + US).
+        // Fallback: same language, any region (e.g. any "en").
+        // Final fallback: first supported locale (should never be empty).
+        let matched = supported.first(where: {
+            $0.language.languageCode?.identifier == userLang
+                && $0.language.region?.identifier == userRegion
+        }) ?? supported.first(where: {
+            $0.language.languageCode?.identifier == userLang
+        })
+
+        guard let resolvedLocale = matched else {
+            isUnavailableForSession = true
+            state = .unavailable(.recognizerUnavailable)
+            return
+        }
+
+        // Step 4 — Heavy setup runs OFF main actor on a detached task.
+        // This is load-bearing: every sync AVAudioSession / engine
+        // call inside would block the main thread otherwise, freezing
+        // the UI.
+        let setupResult: SetupResult
+        do {
+            setupResult = try await Task.detached(priority: .userInitiated) {
+                try await Self.performHeavySetup(locale: resolvedLocale)
+            }.value
+        } catch {
+            guard gen == startGeneration else { return }
+            log.error("Voice setup failed: \(error.localizedDescription, privacy: .public)")
+            tearDownSync()
+            state = .unavailable(.audioEngineFailed)
+            return
+        }
+
+        // Back on main actor — store resources.
+        guard gen == startGeneration else {
+            // Abandoned while we awaited. Clean up the resources we
+            // just created so the mic indicator doesn't linger.
+            Self.tearDownResources(setupResult)
+            return
+        }
+
+        self.engine = setupResult.engine
+        self.transcriber = setupResult.transcriber
+        self.analyzer = setupResult.analyzer
+        self.audioContinuation = setupResult.continuation
+        self.audioSessionActive = true
+        self.tapInstalled = true
+
+        // Analyze task — consumes the audio stream. Runs until the
+        // stream finishes (we call continuation.finish() in teardown).
+        let analyzer = setupResult.analyzer
+        let analyzerStream = setupResult.analyzerStream
+        self.analyzeTask = Task.detached(priority: .userInitiated) {
+            do {
+                try await analyzer.analyzeSequence(analyzerStream)
+            } catch {
+                // Expected on cancellation/teardown — don't flap state.
+            }
+        }
+
+        // Results loop — hops to main for each transcriber result.
+        let transcriber = setupResult.transcriber
+        self.resultsTask = Task { [weak self] in
+            do {
+                for try await result in transcriber.results {
+                    await self?.handleTranscriberResult(result)
+                }
+            } catch {
+                // Stream closed on teardown — normal.
+            }
+        }
+
+        currentPartial = ""
+        state = .listening
+        resetSilenceTimer()
+    }
+
+    func commit() {
+        // If user tapped stop while still in permission phase, treat
+        // as cancel — bump generation so the in-flight setup bails
+        // when it tries to transition to .listening.
+        if case .requestingPermission = state {
+            cancel()
+            return
+        }
+        guard case .listening = state else {
+            tearDownSync()
+            return
+        }
+        let partial = currentPartial
+        // Idempotent: don't launch a second finalize if one is
+        // already in flight.
+        if isFinalizing { return }
+        isFinalizing = true
+
+        // Cancel silence timer — we're finalizing now.
+        silenceTask?.cancel(); silenceTask = nil
+
+        // Finish the audio stream (signals analyzer that input ended).
+        let continuation = audioContinuation
+        let analyzer = self.analyzer
+        finalizeTask?.cancel()
+        finalizeTask = Task { [weak self] in
+            continuation?.finish()
+            do {
+                try await analyzer?.finalizeAndFinishThroughEndOfInput()
+            } catch {
+                // Log only; we still fall through to fallback.
+            }
+
+            // Fallback: if no final result arrives in 700ms, commit
+            // with the partial we had at commit-time.
+            try? await Task.sleep(for: .milliseconds(700))
+            await self?.fallbackFinalize(with: partial)
+        }
+    }
+
+    func cancel() {
+        startGeneration &+= 1
+        if case .committed = state {
+            // Commit already landed — preserve lastFinalText.
+            tearDownSync()
+            return
+        }
+        lastFinalText = ""
+        tearDownSync()
+        state = .idle
+    }
+
+    // MARK: - Heavy setup (OFF main actor)
+
+    /// Setup result bundle — Sendable so it crosses actor boundaries.
+    private struct SetupResult: @unchecked Sendable {
+        let engine: AVAudioEngine
+        let transcriber: SpeechTranscriber
+        let analyzer: SpeechAnalyzer
+        let continuation: AsyncStream<AnalyzerInput>.Continuation
+        let analyzerStream: AsyncStream<AnalyzerInput>
+    }
+
+    nonisolated private static func performHeavySetup(locale: Locale) async throws -> SetupResult {
+        // 1. Build transcriber.
+        let transcriber = SpeechTranscriber(
+            locale: locale,
+            transcriptionOptions: [],
+            reportingOptions: [.volatileResults],
+            attributeOptions: [.audioTimeRange]
+        )
+
+        // 2. Ensure language model is downloaded. No-op if installed.
+        if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
+            try await request.downloadAndInstall()
+        }
+
+        // 3. Audio session — off-main, safe to block.
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.record, mode: .measurement, options: [])
+        try session.setActive(true, options: [])
+
+        // 4. Best format for this transcriber — the format
+        // SpeechAnalyzer wants us to deliver (e.g., 16 kHz Int16 for
+        // speech). NOT the format the mic hardware produces.
+        let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber])
+
+        // 5. Engine + tap.
+        //
+        // CRITICAL: `installTap(format:)` REQUIRES the input node's
+        // native hardware format (e.g., 48 kHz Float32 on iPhone 17
+        // Pro). Passing any other format throws
+        // `com.apple.coreaudio.avfaudio` and crashes the app — this
+        // exception is uncaught, so the whole app terminates silently
+        // and looks like a freeze. Previous version passed the
+        // analyzer's preferred format here, which is wrong.
+        //
+        // The fix: tap with the input's native format, then convert
+        // each buffer to the analyzer's format via AVAudioConverter
+        // before yielding to the stream.
+        let engine = AVAudioEngine()
+        let inputNode = engine.inputNode
+        let inputFormat = inputNode.outputFormat(forBus: 0)
+
+        // Build converter if analyzer needs a different format.
+        let converter: AVAudioConverter?
+        if let analyzerFormat, analyzerFormat != inputFormat {
+            converter = AVAudioConverter(from: inputFormat, to: analyzerFormat)
+        } else {
+            converter = nil
+        }
+
+        // 6. Audio buffer stream. Emits AnalyzerInput.
+        //
+        // CoreAudio reuses the same buffer pool for installTap
+        // callbacks, so we must copy (or convert to a new buffer)
+        // before yielding. The AVAudioConverter path below always
+        // produces a fresh destination buffer, so it doubles as a copy.
+        let (analyzerStream, continuation) = AsyncStream.makeStream(of: AnalyzerInput.self)
+        let outputFormat = analyzerFormat ?? inputFormat
+
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { buffer, _ in
+            if let converter {
+                // Resample/reformat to analyzer's preferred format.
+                // Output buffer capacity: proportional to input frames
+                // scaled by sample-rate ratio. Use a safe upper bound.
+                let ratio = outputFormat.sampleRate / inputFormat.sampleRate
+                let capacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio * 1.1) + 32
+                guard let out = AVAudioPCMBuffer(
+                    pcmFormat: outputFormat,
+                    frameCapacity: capacity
+                ) else { return }
+
+                var error: NSError?
+                var consumed = false
+                let status = converter.convert(to: out, error: &error) { _, inputStatus in
+                    if consumed {
+                        inputStatus.pointee = .noDataNow
+                        return nil
+                    }
+                    consumed = true
+                    inputStatus.pointee = .haveData
+                    return buffer
+                }
+
+                guard status != .error, error == nil else { return }
+                continuation.yield(AnalyzerInput(buffer: out))
+            } else {
+                // Formats match — just copy the buffer to detach it
+                // from CoreAudio's recycled pool.
+                guard let copy = AVAudioPCMBuffer(
+                    pcmFormat: buffer.format,
+                    frameCapacity: buffer.frameLength
+                ) else { return }
+                copy.frameLength = buffer.frameLength
+                if let src = buffer.floatChannelData,
+                   let dst = copy.floatChannelData {
+                    let channels = Int(buffer.format.channelCount)
+                    let frames = Int(buffer.frameLength)
+                    for c in 0..<channels {
+                        memcpy(dst[c], src[c], frames * MemoryLayout<Float>.size)
+                    }
+                } else if let src = buffer.int16ChannelData,
+                          let dst = copy.int16ChannelData {
+                    let channels = Int(buffer.format.channelCount)
+                    let frames = Int(buffer.frameLength)
+                    for c in 0..<channels {
+                        memcpy(dst[c], src[c], frames * MemoryLayout<Int16>.size)
+                    }
+                }
+                continuation.yield(AnalyzerInput(buffer: copy))
+            }
+        }
+
+        engine.prepare()
+        try engine.start()
+
+        // 7. SpeechAnalyzer consumes the AnalyzerInput stream directly.
+        let analyzer = SpeechAnalyzer(modules: [transcriber])
+
+        return SetupResult(
+            engine: engine,
+            transcriber: transcriber,
+            analyzer: analyzer,
+            continuation: continuation,
+            analyzerStream: analyzerStream
+        )
+    }
+
+    /// Clean up resources that were created but not wired into the
+    /// instance (e.g., start() was abandoned mid-setup).
+    nonisolated private static func tearDownResources(_ r: SetupResult) {
+        r.continuation.finish()
+        r.engine.inputNode.removeTap(onBus: 0)
+        if r.engine.isRunning { r.engine.stop() }
+        try? AVAudioSession.sharedInstance()
+            .setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    // MARK: - Result handling (main actor)
+
+    private func handleTranscriberResult(_ result: SpeechTranscriber.Result) {
+        let text = String(result.text.characters)
+        if result.isFinal {
+            // Guard: if we already transitioned past .listening (e.g.,
+            // fallback finalize or cancel beat us to it), drop this
+            // result. Prevents double-state-flip and stale-session
+            // results overwriting current state. (Multi-source finding.)
+            guard case .listening = state else { return }
+            // Cancel any pending fallback-finalize timer so it can't
+            // re-commit with stale partial text.
+            finalizeTask?.cancel(); finalizeTask = nil
+            lastFinalText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            tearDownSync()
+            state = .committed(final: lastFinalText)
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(for: .milliseconds(50))
+                guard let self, case .committed = self.state else { return }
+                self.state = .idle
+            }
+        } else {
+            // Partial result: update the private partial text but
+            // do NOT touch @Published state. That's the entire point
+            // of the simplification — avoid re-rendering ChatView on
+            // every partial. Reset the silence timer so auto-commit
+            // moves forward as new words arrive.
+            guard case .listening = state else { return }
+            currentPartial = text
+            resetSilenceTimer()
+        }
+    }
+
+    private func fallbackFinalize(with partial: String) async {
+        // If a real isFinal result already arrived and transitioned
+        // us to .committed (or anywhere else), don't overwrite.
+        // Prevents double-state-flip when isFinal lands during the
+        // 700ms fallback sleep.
+        guard case .listening = state else { return }
+        let trimmed = partial.trimmingCharacters(in: .whitespacesAndNewlines)
+        lastFinalText = trimmed
+        tearDownSync()
+        state = .committed(final: trimmed)
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(50))
+            guard let self, case .committed = self.state else { return }
+            self.state = .idle
+        }
+    }
+
+    // MARK: - Silence timer (main actor)
+
+    private func resetSilenceTimer() {
+        silenceTask?.cancel()
+        // Progress ticker removed — it was mutating @Published state
+        // 30 times per second, saturating the main actor with ChatView
+        // re-renders. Nothing in the current edge-glow UI reads the
+        // silence progress, so we just keep the auto-commit timer.
+        silenceTask = Task { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(for: .seconds(self.silenceTotal))
+            if Task.isCancelled { return }
+            self.commit()
+        }
+    }
+
+    // MARK: - Teardown
+
+    private func tearDownSync() {
+        isFinalizing = false
+        currentPartial = ""
+        silenceTask?.cancel(); silenceTask = nil
+        finalizeTask?.cancel(); finalizeTask = nil
+
+        audioContinuation?.finish()
+        audioContinuation = nil
+
+        resultsTask?.cancel(); resultsTask = nil
+        analyzeTask?.cancel(); analyzeTask = nil
+
+        if tapInstalled {
+            engine?.inputNode.removeTap(onBus: 0)
+            tapInstalled = false
+        }
+        if let engine, engine.isRunning {
+            engine.stop()
+        }
+        engine = nil
+
+        if audioSessionActive {
+            try? AVAudioSession.sharedInstance()
+                .setActive(false, options: .notifyOthersOnDeactivation)
+            audioSessionActive = false
+        }
+
+        analyzer = nil
+        transcriber = nil
+    }
+}

--- a/ios/Nod/Info.plist
+++ b/ios/Nod/Info.plist
@@ -44,5 +44,9 @@
 	<false/>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Nod uses Face ID to keep your journal private on this device.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Nod uses on-device speech recognition so you can talk instead of type. Your voice never leaves this device.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Nod uses the microphone to hear what you say when you tap the mic. Your voice never leaves this device.</string>
 </dict>
 </plist>

--- a/ios/Nod/Views/ChatView.swift
+++ b/ios/Nod/Views/ChatView.swift
@@ -94,6 +94,65 @@ struct ChatView: View {
     /// via `.task(id:)` on the count + last-id composite.
     @State private var cachedRows: [ChatView.ChatRow] = []
 
+    // MARK: - Dictation state
+
+    /// Owns the on-device speech recognition pipeline (AVAudioEngine +
+    /// SFSpeechRecognizer). Lives on ChatView so the mic indicator
+    /// teardown survives overlay dismissal and scenePhase changes.
+    @StateObject private var dictationRecognizer = DictationRecognizer()
+
+    // Dictation runs inline now — no overlay, no fullScreenCover.
+    // The mic button toggles recording directly via
+    // `dictationRecognizer.start()` / `.commit()`. While recording,
+    // `isRecording` (computed from `dictationRecognizer.state`)
+    // drives the mic-becomes-stop icon swap and the edge glow.
+
+    /// Set each time dictation commits a non-empty transcript. Watched
+    /// by the input field's post-commit pulse animation so the user's
+    /// eye catches misheard words before they tap send. Never
+    /// persisted — pure UI signal.
+    @State private var committedAt: Date?
+
+    /// True when the mic button has been tapped at least once in this
+    /// session. Until then, render a subtle .symbolEffect(.pulse) on
+    /// the mic icon to hint discoverability.
+    @AppStorage("dictation.hasTappedMic") private var hasTappedMic: Bool = false
+
+    /// Two-mode right-side action button. Mic has its own dedicated
+    /// button (see `micButton` in the input bar) so the send arrow
+    /// stays put and never "disappears" into a mic icon when the
+    /// input is empty. Clearer mental model: send-arrow means send,
+    /// always; tapping the separate mic icon means talk instead.
+    private enum SendButtonRole: Equatable {
+        case send  // text present, not streaming → send
+        case stop  // streaming → cancel
+
+        static func from(isInferring: Bool) -> SendButtonRole {
+            isInferring ? .stop : .send
+        }
+
+        var iconName: String {
+            switch self {
+            case .send: return "arrow.up"
+            case .stop: return "stop.fill"
+            }
+        }
+
+        var a11yLabel: String {
+            switch self {
+            case .send: return "Send message"
+            case .stop: return "Stop response"
+            }
+        }
+
+        var a11yHint: String {
+            switch self {
+            case .send: return ""
+            case .stop: return "Stops the current reply; partial text is preserved"
+            }
+        }
+    }
+
     /// True when the scroll view's visible area reaches the bottom of
     /// the content. Measured via `.onScrollGeometryChange` below, so
     /// it reflects REAL layout (content offset + container height vs
@@ -377,6 +436,34 @@ struct ChatView: View {
                     // Warning haptic confirms the destructive action landed.
                     UINotificationFeedbackGenerator().notificationOccurred(.warning)
                 }
+            }
+            // Dictation state observer.
+            //
+            // The recording UI is just: the mic button morphs to a
+            // stop icon AND an orange edge glow appears around the
+            // app while recording. No modal, no fullscreen view,
+            // no mascot. Siri-style ambient presence.
+            //
+            // When the recognizer transitions to .committed, we
+            // capture the transcript, append it to the input field,
+            // and raise the keyboard so the user can edit before
+            // sending. Missed-state fallback on .idle: if SwiftUI
+            // coalesces .committed→.idle and we see only .idle with
+            // non-empty lastFinalText, deliver it anyway.
+            .onChange(of: dictationRecognizer.state) { oldValue, newValue in
+                handleDictationStateChange(from: oldValue, to: newValue)
+            }
+            // Siri-style edge glow. When dictation is active, a soft
+            // orange halo traces the phone's outer edge. Fades in/out
+            // over 300ms. Single view, single animation driver via
+            // `.opacity(isRecording ? 1 : 0)` + `.animation` — no
+            // repeatForever, no overlapping transactions.
+            .overlay(alignment: .center) {
+                recordingEdgeGlow
+                    .opacity(isRecording ? 1 : 0)
+                    .animation(.easeInOut(duration: 0.3), value: isRecording)
+                    .allowsHitTesting(false)
+                    .ignoresSafeArea()
             }
             // "Pause download?" confirmation. Default action is "Keep
             // downloading" (safer on accidental tap). "Pause" is .cancel
@@ -819,11 +906,22 @@ struct ChatView: View {
 
     private var inputBar: some View {
         HStack(spacing: 10) {
-            // The text field handles both typing AND dictation — iOS's
-            // built-in keyboard has a mic button in the bottom-right that
-            // dictates into any focused text field, on-device on
-            // Apple-Intelligence-capable devices. We don't need our own
-            // mic button or mic-handling code.
+            // Dedicated mic button, LEFT of the text field. Always
+            // visible when not streaming (hidden during inference so
+            // you can't talk over Nod thinking). Having mic as its
+            // own button keeps the send arrow always present — no
+            // disappearing send-becomes-mic swap that confused users
+            // about where their "send" went.
+            if !isInferring && !dictationRecognizer.isUnavailableForSession {
+                micButton
+            }
+
+            // Text field with a post-commit underline pulse that
+            // briefly flashes in NodAccent when a dictation commit
+            // lands. Catches the user's eye so they notice misheard
+            // words (a trust break on a venting app) before tapping
+            // send. `committedAt` is the trigger; the overlay modifier
+            // drives opacity 0→1→0 over ~1.5s.
             TextField("Type what's on your mind…", text: $inputText, axis: .vertical)
                 .textFieldStyle(.plain)
                 .lineLimit(1...5)
@@ -831,6 +929,13 @@ struct ChatView: View {
                 .padding(.vertical, 10)
                 .background(Color(.secondarySystemBackground))
                 .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                .overlay(alignment: .bottom) {
+                    if let committedAt {
+                        PostCommitPulse(trigger: committedAt)
+                            .allowsHitTesting(false)
+                            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    }
+                }
                 .focused($inputFocused)
                 .accessibilityLabel("Message")
                 // No .submitLabel(.send)/.onSubmit here: with axis: .vertical
@@ -839,62 +944,174 @@ struct ChatView: View {
                 // lie. Hardware keyboards get Cmd+Return via the shortcut
                 // button in .background above.
 
-            // Dual-purpose send/stop button. When Nod is streaming, the
-            // icon morphs to `stop.fill`, the fill shifts from NodAccent
-            // orange to a neutral gray, and the accessibility label
-            // swaps from "Send message" to "Stop response" — three
-            // coordinated cues so the new role reads instantly.
-            //
-            // Tap behavior forks on `isInferring`:
-            //   - idle → sendMessage()
-            //   - streaming → inferenceTask?.cancel() (real GPU stop)
+            // Two-state right-side action button: send / stop.
+            //   - Streaming → stop.fill, gray, tap cancels inference
+            //   - Otherwise → arrow.up, NodAccent, tap sends
+            // `.contentTransition(.symbolEffect(.replace.downUp))`
+            // morphs the icon smoothly; fill animates via `.animation`
+            // on the role. Mic is a separate button above — this one
+            // never becomes a mic.
+            let role = SendButtonRole.from(isInferring: isInferring)
             Button {
-                if isInferring {
-                    UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
-                    inferenceTask?.cancel()
-                } else {
-                    sendMessage()
-                }
+                handleSendButtonTap(role: role)
             } label: {
                 ZStack {
                     Circle()
-                        .fill(sendButtonFill)
+                        .fill(sendButtonFill(for: role))
                         .frame(width: 32, height: 32)
-                    Image(systemName: isInferring ? "stop.fill" : "arrow.up")
+                    Image(systemName: role.iconName)
                         .font(.system(size: 14, weight: .bold))
-                        .foregroundStyle(sendButtonIconColor)
+                        .foregroundStyle(sendButtonIconColor(for: role))
                         .contentTransition(.symbolEffect(.replace.downUp))
                 }
-                .animation(.easeInOut(duration: 0.15), value: isInferring)
+                .animation(.easeInOut(duration: 0.15), value: role)
             }
-            .disabled(isInferring ? inferenceTask == nil : !sendEnabled)
-            .accessibilityLabel(isInferring ? "Stop response" : "Send message")
-            .accessibilityHint(isInferring
-                ? "Stops the current reply; partial text is preserved"
-                : "")
+            .disabled(isSendButtonDisabled(for: role))
+            .accessibilityLabel(role.a11yLabel)
+            .accessibilityHint(role.a11yHint)
         }
     }
 
-    /// Fill color for the send/stop button. Orange NodAccent in idle
-    /// state (the "you'd send here" affordance), neutral gray when
-    /// streaming (the "this is a different action" visual tell). Also
-    /// dims to secondary fill when the button is genuinely disabled
-    /// (pre-hydrate, empty input, etc.).
-    private var sendButtonFill: Color {
-        if isInferring {
+    /// True when we're actively capturing voice. Used to morph the
+    /// mic button into a stop button and to show the edge glow.
+    private var isRecording: Bool {
+        switch dictationRecognizer.state {
+        case .listening, .requestingPermission:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Dedicated mic button (left of the text field). Two-state:
+    ///   - Not recording: mic icon, tap → `recognizer.start()`
+    ///   - Recording:     stop icon, tap → `recognizer.commit()`
+    ///     transcript lands in the input field via the state observer
+    ///     on recognizer.state == .committed.
+    private var micButton: some View {
+        Button {
+            hasTappedMic = true
+            if isRecording {
+                UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
+                dictationRecognizer.commit()
+            } else {
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                Task { await dictationRecognizer.start() }
+            }
+        } label: {
+            Image(systemName: isRecording ? "stop.fill" : "mic.fill")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(isRecording ? .black : Color("NodAccent"))
+                .frame(width: 32, height: 32)
+                .background(
+                    Circle().fill(
+                        isRecording ? Color("NodAccent") : Color(.secondarySystemBackground)
+                    )
+                )
+                .contentTransition(.symbolEffect(.replace.downUp))
+                .symbolEffect(
+                    .pulse,
+                    options: .repeat(2),
+                    isActive: !hasTappedMic && !isRecording
+                )
+        }
+        .animation(.easeInOut(duration: 0.15), value: isRecording)
+        .accessibilityLabel(isRecording ? "Stop dictation" : "Start dictation")
+        .accessibilityHint(isRecording
+            ? "Inserts the transcript into the message field"
+            : "Records what you say and transcribes it")
+    }
+
+    /// Siri-style edge glow that traces the phone's outer rectangle
+    /// when dictation is active. Single stroked rounded-rectangle
+    /// with a blurred NodAccent outline. No rotation, no
+    /// repeatForever — just an opacity fade driven by `isRecording`
+    /// via the parent's `.animation` modifier. Safe by construction.
+    private var recordingEdgeGlow: some View {
+        RoundedRectangle(cornerRadius: 58, style: .continuous)
+            .inset(by: -4)
+            .stroke(Color("NodAccent"), lineWidth: 16)
+            .blur(radius: 14)
+    }
+
+    /// Handles transcript delivery. When the recognizer commits, we
+    /// pick up `lastFinalText`, append it to the input field, and
+    /// focus the text field so the user can edit or send. Empty
+    /// commit silently dismisses. Fallback on .idle covers the case
+    /// where SwiftUI coalesced .committed→.idle into a single
+    /// delivery.
+    private func handleDictationStateChange(
+        from oldValue: DictationRecognizer.State,
+        to newValue: DictationRecognizer.State
+    ) {
+        // `.committed` is the only reliable delivery signal. The old
+        // `.idle`/`.unavailable` fallback (which read lastFinalText)
+        // was dangerous — it could re-insert the previous session's
+        // transcript if the new start() failed before committing.
+        // The recognizer now clears lastFinalText at start(), and
+        // SpeechAnalyzer's stream-based results reliably hit
+        // `.committed` before transitioning to `.idle`.
+        if case .committed = newValue {
+            deliverTranscript(dictationRecognizer.lastFinalText)
+        }
+    }
+
+    private func deliverTranscript(_ finalText: String) {
+        let trimmed = finalText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        // Append to existing text, trim-aware so whitespace-only
+        // drafts don't leave leading spaces before the transcript.
+        let existing = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        inputText = existing.isEmpty ? trimmed : existing + " " + trimmed
+        committedAt = Date()
+        // Raise the keyboard so they can edit or send. Delayed one
+        // tick so focus lands after the send/cancel tap finishes.
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(50))
+            inputFocused = true
+        }
+    }
+
+    /// Tap dispatch for the two-state send/stop button.
+    private func handleSendButtonTap(role: SendButtonRole) {
+        switch role {
+        case .stop:
+            UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
+            inferenceTask?.cancel()
+        case .send:
+            sendMessage()
+        }
+    }
+
+    private func isSendButtonDisabled(for role: SendButtonRole) -> Bool {
+        switch role {
+        case .stop: return inferenceTask == nil
+        case .send: return !sendEnabled
+        }
+    }
+
+    /// Fill color for the send/stop button. NodAccent when ready to
+    /// send; neutral gray when streaming (stop); dim tertiary when
+    /// genuinely disabled (empty input pre-hydrate).
+    private func sendButtonFill(for role: SendButtonRole) -> Color {
+        switch role {
+        case .stop:
             return Color(.secondarySystemBackground)
+        case .send:
+            return sendEnabled ? Color("NodAccent") : Color(.tertiarySystemFill)
         }
-        return sendEnabled ? Color("NodAccent") : Color(.tertiarySystemFill)
     }
 
-    private var sendButtonIconColor: Color {
-        if isInferring {
+    private func sendButtonIconColor(for role: SendButtonRole) -> Color {
+        switch role {
+        case .stop:
             // Black on the gray stop circle for high contrast in both
             // light and dark modes. `.primary` would invert with theme
             // and lose contrast against the neutral gray fill.
             return .primary
+        case .send:
+            return sendEnabled ? .black : .secondary
         }
-        return sendEnabled ? .black : .secondary
     }
 
     private var sendEnabled: Bool {
@@ -2216,4 +2433,46 @@ private struct AFMUnavailableBanner: View {
     ChatView()
         .environmentObject(AppLockManager())
         .preferredColorScheme(.dark)
+}
+
+// MARK: - Post-commit pulse
+
+/// Brief NodAccent underline that fades in-and-out across the input
+/// field after a dictation transcript lands. Purely visual — catches
+/// the user's eye so misheard words get noticed before tap-to-send.
+///
+/// Keyed on a Date trigger passed from ChatView; every new commit
+/// replaces the date and re-triggers the animation via `onChange`.
+private struct PostCommitPulse: View {
+    let trigger: Date
+    @State private var opacity: Double = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        Rectangle()
+            .fill(Color("NodAccent"))
+            .frame(maxWidth: .infinity)
+            .frame(height: 2)
+            .opacity(opacity)
+            .onAppear { animate() }
+            .onChange(of: trigger) { _, _ in animate() }
+    }
+
+    private func animate() {
+        // Instant up, then gentle fade out over ~1.5s. Reduce-motion
+        // users get the same signal minus the fade (still attention
+        // without movement).
+        if reduceMotion {
+            opacity = 1
+            Task { @MainActor in
+                try? await Task.sleep(for: .seconds(1.5))
+                opacity = 0
+            }
+            return
+        }
+        opacity = 1
+        withAnimation(.easeOut(duration: 1.5)) {
+            opacity = 0
+        }
+    }
 }

--- a/ios/Nod/Views/SidebarView.swift
+++ b/ios/Nod/Views/SidebarView.swift
@@ -302,6 +302,13 @@ struct SidebarView: View {
                     }
                 } header: {
                     Text("About")
+                } footer: {
+                    // Product stance, surfaced so the "why doesn't
+                    // it talk back?" question has an answer users
+                    // can find without asking. Nod listens (voice
+                    // in) but writes replies (text out) on purpose —
+                    // see design notes in the voice feature plan.
+                    Text("Nod listens but never speaks — replies arrive as writing, on purpose.")
                 }
             }
             // The Personalisation free-form TextField brings up the


### PR DESCRIPTION
## Summary
- Tap the mic button in the chat input → speak → transcript appears in the text field. Full-screen orange edge glow animates while recording.
- Uses **iOS 26 SpeechAnalyzer + SpeechTranscriber** (not the legacy SFSpeechRecognizer). On-device, async-by-design, zero network.
- Auto-commits after 2.5s of silence or when the user taps stop. The mic button morphs into a stop glyph mid-recording.
- Surfaces the product stance in the sidebar footer: _"Nod listens but never speaks — replies arrive as writing, on purpose."_

## Why this architecture
- **Heavy setup runs off the main actor.** Every sync AVAudioSession/engine call would freeze the UI if left on `@MainActor`. `Task.detached` owns the setup and only hops back for `@Published` mutations.
- **`installTap(format:)` must use the input node's NATIVE hardware format.** Passing the analyzer's preferred 16kHz Int16 directly throws an uncatchable `com.apple.coreaudio.avfaudio` NSException and silently terminates the app (looks like a freeze). Fix: tap with native format (48kHz Float32), then `AVAudioConverter` resamples each buffer to the analyzer's format before yielding to the AsyncStream.
- **Partial results skip `@Published`.** Partial transcriber results fire dozens of times per second — routing them through `@Published` saturated the main actor with re-renders. Only true state transitions (idle → listening → committed) fire `objectWillChange`.
- **Locale fallback.** `SpeechTranscriber.supportedLocales` returns base locales like `en-US`; user locales like `en_US@rg=inzzzz` fail exact match. Fall back to language-code match, then region.

## Files
- **new:** `ios/Nod/Inference/DictationRecognizer.swift` — the whole recognizer in 554 lines, heavily commented.
- `ios/Nod/Views/ChatView.swift` — mic button, edge glow overlay, wiring.
- `ios/Nod/Views/SidebarView.swift` — footer copy explaining the voice-in/text-out choice.
- `ios/Nod/Info.plist` — `NSSpeechRecognitionUsageDescription`, `NSMicrophoneUsageDescription` (both emphasize on-device).
- `.gitignore` — exclude `ios/build-device/`, `ios/build-sim/`.
- Xcode project/scheme updated to include the new file.

## Test plan
- [ ] Fresh install → tap mic → both permission prompts appear with the on-device copy.
- [ ] First record after install may download the language model (shows a brief delay, then proceeds).
- [ ] Record something → stop → transcript appears in the input, user can edit before sending.
- [ ] Stay silent 2.5s mid-record → auto-commits.
- [ ] Deny mic or speech permission → recorder transitions to unavailable, mic button hidden.
- [ ] Kill app mid-record → audio session releases cleanly, no stuck red mic indicator.
- [ ] Switch to Airplane Mode → voice still works (on-device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>