### PR TITLE
polish: unify mascot across app + stop keyboard hijack after dictation

### DIFF
--- a/ios/Nod.xcodeproj/project.pbxproj
+++ b/ios/Nod.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		B289E4BB871E286AB3B42237 /* MLXModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1EA52E2C7A708C854BB9AF5 /* MLXModelSpec.swift */; };
 		B5BC7D4A4DC14AAD114A01DE /* MLXR2BackgroundSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C6540C9C1E33F6B053CCD4 /* MLXR2BackgroundSession.swift */; };
 		C24E2CCA2BCF01FB3AD383D9 /* AppLockOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9F9FCA04E591DBC2EFA635 /* AppLockOverlay.swift */; };
+		C5645CF43C594398A3AC3EBD /* NodMascot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC11E94F0CAF443B85BADD1D /* NodMascot.swift */; };
 		C7C3B6E45145A51AE7E271BC /* MiniNodFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A37C05BFA242FCFBFC522A /* MiniNodFace.swift */; };
 		CD1DCEE44A282AA7684E5821 /* SpeedWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C53F1411A95FAB7142921F /* SpeedWindow.swift */; };
 		CDAAAC3781D310A60DC2D9A2 /* AppLockManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A403C8B5DDD2D7732FE7942 /* AppLockManager.swift */; };
@@ -77,6 +78,7 @@
 		964ADD3303489CFCB3C4EF5D /* DownloadEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadEvent.swift; sourceTree = "<group>"; };
 		A7B129F4799D29E72530A088 /* InferenceEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InferenceEngine.swift; sourceTree = "<group>"; };
 		B4A37C05BFA242FCFBFC522A /* MiniNodFace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniNodFace.swift; sourceTree = "<group>"; };
+		BC11E94F0CAF443B85BADD1D /* NodMascot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodMascot.swift; sourceTree = "<group>"; };
 		C1EA52E2C7A708C854BB9AF5 /* MLXModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLXModelSpec.swift; sourceTree = "<group>"; };
 		C327F0BBE1FD3F6B8D9BAEEC /* MessageDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDatabase.swift; sourceTree = "<group>"; };
 		C3F8BEB5AAF0BA2824DE66A5 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
@@ -112,6 +114,7 @@
 				0437418B2F3A7A98F6F4B089 /* MemoryView.swift */,
 				B4A37C05BFA242FCFBFC522A /* MiniNodFace.swift */,
 				83E9E17AF4055789FC092B5E /* NodAnimation.swift */,
+				BC11E94F0CAF443B85BADD1D /* NodMascot.swift */,
 				0517337BBD8316AD61402BEF /* SidebarView.swift */,
 				C3F8BEB5AAF0BA2824DE66A5 /* SplashView.swift */,
 			);
@@ -331,6 +334,7 @@
 				E3DDA822B23BD5369C74E59A /* MessageDatabase.swift in Sources */,
 				C7C3B6E45145A51AE7E271BC /* MiniNodFace.swift in Sources */,
 				89331638D0D309292F560723 /* NodAnimation.swift in Sources */,
+				C5645CF43C594398A3AC3EBD /* NodMascot.swift in Sources */,
 				26FB0074AE17C845461190DB /* NodApp.swift in Sources */,
 				0CC71701F46352365F79EEA8 /* PersonalizationStore.swift in Sources */,
 				AF9E706F9859892FA91B6553 /* SidebarView.swift in Sources */,

--- a/ios/Nod/Views/ChatView.swift
+++ b/ios/Nod/Views/ChatView.swift
@@ -1064,12 +1064,13 @@ struct ChatView: View {
         let existing = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
         inputText = existing.isEmpty ? trimmed : existing + " " + trimmed
         committedAt = Date()
-        // Raise the keyboard so they can edit or send. Delayed one
-        // tick so focus lands after the send/cancel tap finishes.
-        Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(50))
-            inputFocused = true
-        }
+        // Deliberately do NOT raise the keyboard here. The voice
+        // experience is spoken, not typed — popping the keyboard right
+        // after commit yanks the user out of the voice flow and into
+        // typing mode. The send button sits in the input row and is
+        // tappable regardless of focus, so they can ship the message
+        // without touching the keyboard. If they want to edit, they
+        // tap the field themselves.
     }
 
     /// Tap dispatch for the two-state send/stop button.
@@ -2162,23 +2163,12 @@ private struct AFMUnavailableOnboarding: View {
 
     // MARK: Hero
 
-    /// 88pt mascot — the hero size. Larger than the 28pt nav-bar
-    /// mascot; codified as the "hero moment" token (will move into
-    /// DESIGN.md when that ships).
+    /// 88pt mascot — the hero size. Larger than the 32pt nav-bar
+    /// mascot; codified as the "hero moment" token. Uses the canonical
+    /// NodMascot so the onboarding first-impression matches the app
+    /// icon users just tapped.
     private var heroMascot: some View {
-        // Simplest rendering: the orange rounded-square + two eyes,
-        // identical geometry to MiniNodFace but scaled up. Not reusing
-        // MiniNodFace because that view has a blink timer, and a
-        // full-size hero asset doesn't need eye animation here.
-        RoundedRectangle(cornerRadius: 22, style: .continuous)
-            .fill(Color("NodAccent"))
-            .frame(width: 88, height: 88)
-            .overlay(
-                HStack(spacing: 12) {
-                    Circle().fill(Color.black).frame(width: 12, height: 12)
-                    Circle().fill(Color.black).frame(width: 12, height: 12)
-                }
-            )
+        NodMascot(size: 88)
             .padding(.top, 64)
             .padding(.bottom, 28)
             .opacity(afmStatus == .notSupported && !canRunMLX ? 0.85 : 1.0)

--- a/ios/Nod/Views/MiniNodFace.swift
+++ b/ios/Nod/Views/MiniNodFace.swift
@@ -1,7 +1,10 @@
 // MiniNodFace.swift
-// A small rounded-square Nod face with auto-blinking eyes. Used as the
-// navigation bar's leading brand element (replaces the "Nod" title). In
-// the future, tapping it opens a sidebar — stub action for now.
+// Blinking variant of the canonical NodMascot, used as the navigation
+// bar's leading brand element (replaces the "Nod" title). In the
+// future, tapping it opens a sidebar — stub action for now.
+//
+// The face geometry (body, eyes, glimmer, proportions) lives in
+// NodMascot. This view just drives the blink state on top.
 
 import SwiftUI
 
@@ -13,24 +16,10 @@ struct MiniNodFace: View {
     @State private var blinkTask: Task<Void, Never>?
 
     var body: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: size * 0.2237, style: .continuous)
-                .fill(Color("NodAccent"))
-
-            HStack(spacing: size * 0.19) {
-                Ellipse()
-                    .fill(Color(red: 0.08, green: 0.08, blue: 0.08))
-                    .frame(width: size * 0.13, height: size * 0.22)
-                Ellipse()
-                    .fill(Color(red: 0.08, green: 0.08, blue: 0.08))
-                    .frame(width: size * 0.13, height: size * 0.22)
-            }
-            .scaleEffect(y: eyesClosed ? 0.1 : 1.0, anchor: .center)
+        NodMascot(size: size, eyesClosed: eyesClosed)
             .animation(.easeInOut(duration: 0.18), value: eyesClosed)
-        }
-        .frame(width: size, height: size)
-        .onAppear { startBlinking() }
-        .onDisappear { blinkTask?.cancel() }
+            .onAppear { startBlinking() }
+            .onDisappear { blinkTask?.cancel() }
     }
 
     private func startBlinking() {

--- a/ios/Nod/Views/NodMascot.swift
+++ b/ios/Nod/Views/NodMascot.swift
@@ -1,0 +1,87 @@
+// NodMascot.swift
+// The canonical in-app Nod face. THIS view mirrors Icon-1024.png —
+// users should see the same character on the springboard, in onboarding,
+// and in the nav bar. Single source of truth for "Nod's face."
+//
+// If you need Nod to blink or animate, wrap this view and drive
+// `eyesClosed` (that's what MiniNodFace does).
+//
+// Not used for: NodAnimation.swift, which is the floating-eyes beat
+// inside chat bubbles (no face, context-adaptive color).
+
+import SwiftUI
+
+struct NodMascot: View {
+    var size: CGFloat = 88
+    /// Set true to squash the eyes into a blink. Drive this from a
+    /// parent view's animation state (see MiniNodFace).
+    var eyesClosed: Bool = false
+
+    // Proportions pulled from Icon-1024.png. Any drift here is drift
+    // from the app icon — keep these locked unless the icon changes too.
+    private let cornerRatio: CGFloat = 0.2237
+    private let eyeWidthRatio: CGFloat = 0.13
+    private let eyeHeightRatio: CGFloat = 0.22
+    private let eyeSpacingRatio: CGFloat = 0.19
+    /// White highlight dot. ~3.5% of face width at hero sizes; fades
+    /// out at nav-bar scale where it would just be sub-pixel noise.
+    private let glimmerSizeRatio: CGFloat = 0.035
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: size * cornerRatio, style: .continuous)
+                .fill(Color("NodAccent"))
+
+            HStack(spacing: size * eyeSpacingRatio) {
+                eye
+                eye
+            }
+            .scaleEffect(y: eyesClosed ? 0.1 : 1.0, anchor: .center)
+        }
+        .frame(width: size, height: size)
+    }
+
+    private var eye: some View {
+        ZStack {
+            Ellipse()
+                .fill(Color(red: 0.08, green: 0.08, blue: 0.08))
+
+            // The glimmer. Upper-right of eye center, light-source-
+            // upper-left convention. Fades below 40pt because at small
+            // sizes it's either invisible or anti-aliases into a blur.
+            Circle()
+                .fill(Color.white)
+                .frame(width: size * glimmerSizeRatio,
+                       height: size * glimmerSizeRatio)
+                .offset(x: size * eyeWidthRatio * 0.15,
+                        y: -size * eyeHeightRatio * 0.25)
+                .opacity(glimmerOpacity)
+        }
+        .frame(width: size * eyeWidthRatio,
+               height: size * eyeHeightRatio)
+    }
+
+    /// Linear fade from `glimmerFullSize` (full glimmer) down to
+    /// `glimmerFadeSize` (no glimmer). Below the fade floor the eyes
+    /// already read clearly; the glimmer would just be a sub-pixel
+    /// artifact.
+    private var glimmerOpacity: Double {
+        let upper: CGFloat = 40 // glimmerFullSize
+        let lower: CGFloat = 24 // glimmerFadeSize
+        if size >= upper { return 1.0 }
+        if size <= lower { return 0.0 }
+        return Double((size - lower) / (upper - lower))
+    }
+}
+
+#Preview {
+    VStack(spacing: 32) {
+        NodMascot(size: 120) // App-icon-sized preview
+        NodMascot(size: 88)  // Onboarding hero
+        NodMascot(size: 48)  // Still has glimmer
+        NodMascot(size: 32)  // Nav bar — glimmer faded
+        NodMascot(size: 24)  // Below threshold
+    }
+    .padding()
+    .preferredColorScheme(.dark)
+}


### PR DESCRIPTION
## Summary

Two small voice-era polish fixes, one PR. Both came out of using the voice feature on device.

### 1. Mascot unification
The same Nod character rendered three different ways before this PR:

| Where | Eye shape | Glimmer |
|---|---|---|
| App icon | Oval | Yes (white dot) |
| Onboarding hero | **Circle** (bug) | No |
| Nav bar mascot | Oval | No |

Users saw circle eyes on the onboarding hero right after tapping an icon with oval eyes. Subtle drift, visible once you look for it.

- New `NodMascot(size:eyesClosed:)` component. Proportions pinned to `Icon-1024.png`, documented in comments.
- Glimmer fades between 40pt (full) and 24pt (none). Hero (88pt) shows it, nav bar (32pt) drops it cleanly. Sub-pixel dots at small sizes just blur into the eye; cleaner to skip.
- `MiniNodFace` is now a thin blink-timer wrapper around `NodMascot`.
- Onboarding `heroMascot` uses `NodMascot(size: 88)`.
- `NodAnimation` (floating orange eyes in chat bubbles) intentionally untouched — it's a different thing, context-adaptive color, already documented.

### 2. Keyboard-after-dictation fix
`deliverTranscript` used to force `inputFocused = true` 50ms after the voice transcript landed, popping the keyboard open. That yanks the user out of the voice flow into typing mode — the opposite of what a voice experience should do.

The send button is already in the input row and tappable without focus, so a voice-only path works end-to-end with no keyboard. Removed the focus-raising Task. Users can still tap the field if they want to edit.

## Net change
- 4 files, +112 / -42
- 1 new file (`NodMascot.swift`, ~80 LOC)

## Test plan
- [ ] Install fresh on an iPhone that hits the onboarding branch (AFM unavailable) → hero mascot should match the app icon (oval eyes + glimmer dots)
- [ ] Nav bar mascot should still blink smoothly; glimmer should be absent (or nearly so) at 32pt
- [ ] Record voice message → transcript appears → keyboard stays hidden → tap orange send button → message goes
- [ ] Side-by-side: app icon (home screen) vs onboarding hero (app) — eye color should match. If in-app eyes look visibly lighter, flip `Color(red: 0.08...)` → `Color.black` in NodMascot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>