### PR TITLE
feat: add PrivacyInfo.xcprivacy (hard App Store blocker for V1)

### DIFF
--- a/ios/Nod.xcodeproj/project.pbxproj
+++ b/ios/Nod.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		2484EA93E6A4F4DC7305E7BE /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = FD58A9CC136146214D82403C /* GRDB */; };
 		24D408F3CA747F829DE44292 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F8BEB5AAF0BA2824DE66A5 /* SplashView.swift */; };
 		25BAFB93063B4B6B623D96DD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7353A5B91242F165EFCD7D68 /* Assets.xcassets */; };
+		D940AEFD66024420AAED8360 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 77F031A36BD44AA4ADE4A1ED /* PrivacyInfo.xcprivacy */; };
 		26FB0074AE17C845461190DB /* NodApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 420B40291D1B3DE220552641 /* NodApp.swift */; };
 		2C884D7C63A57E9026C13381 /* InferenceEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B129F4799D29E72530A088 /* InferenceEngine.swift */; };
 		36209BB2C752B19E2900045C /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E7655A16D7F32F90AD7401 /* ChatView.swift */; };
@@ -68,6 +69,7 @@
 		6B9F9FCA04E591DBC2EFA635 /* AppLockOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockOverlay.swift; sourceTree = "<group>"; };
 		71720E33D89D0A92B33AD8AB /* DownloadTuning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadTuning.swift; sourceTree = "<group>"; };
 		7353A5B91242F165EFCD7D68 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		77F031A36BD44AA4ADE4A1ED /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		736AB3FA290A115FAEA39CCC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		75E6A0E3A753A5B5C2221D90 /* ConversationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationStore.swift; sourceTree = "<group>"; };
 		760F42DE20FF786A995C7621 /* LaunchCrashBreaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchCrashBreaker.swift; sourceTree = "<group>"; };
@@ -134,6 +136,7 @@
 				7353A5B91242F165EFCD7D68 /* Assets.xcassets */,
 				760F42DE20FF786A995C7621 /* LaunchCrashBreaker.swift */,
 				420B40291D1B3DE220552641 /* NodApp.swift */,
+				77F031A36BD44AA4ADE4A1ED /* PrivacyInfo.xcprivacy */,
 			);
 			path = Nod;
 			sourceTree = "<group>";
@@ -296,6 +299,7 @@
 				25BAFB93063B4B6B623D96DD /* Assets.xcassets in Resources */,
 				A484A82A83997D60C288E522 /* Preview Assets.xcassets in Resources */,
 				D152974FF40E7CF801B96C4B /* prompts in Resources */,
+				D940AEFD66024420AAED8360 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Nod/PrivacyInfo.xcprivacy
+++ b/ios/Nod/PrivacyInfo.xcprivacy
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Privacy Manifest for Nod (Just Nod).
+
+    Required by the App Store since May 2024 for any app using
+    required-reason APIs. Declares:
+
+      1. No user tracking. At all.
+      2. No data collection. At all. Every byte Nod sees stays on the
+         user's device — see https://usenod.app/privacy for the product
+         positioning this backs.
+      3. Which required-reason APIs the app uses, and the approved
+         Apple reason code for each. These are the ONLY two such APIs
+         Nod touches, verified by grep before every release:
+           - UserDefaults     → CA92.1  (reading/writing own app prefs)
+           - File timestamps  → C617.1  (file metadata inside app container)
+
+    If you add code that uses another category listed at
+    https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api,
+    add the corresponding NSPrivacyAccessedAPIType + reason code here.
+    Apple's submission gate reads this file and rejects the build if a
+    used category is undeclared.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+        Tracking — Nod does not track users across apps or websites.
+        Per Apple's definition, this means we do not link user or
+        device identifiers to data collected from other developers.
+        We do neither side of that equation.
+    -->
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+
+    <!--
+        Data collection — Nod collects zero data types. Everything the
+        user writes, says, or generates stays on-device. The app has
+        no network connection except the one-time on-device model
+        download from our R2 CDN, which transfers model weights TO the
+        device, not user data FROM it.
+    -->
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+
+    <!--
+        Required-reason APIs — the complete list for Nod as of build 21.
+    -->
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <!--
+            UserDefaults (NSPrivacyAccessedAPICategoryUserDefaults).
+            Reason CA92.1: "Declare this reason to access user defaults
+            to read and write information that is only accessible to
+            the app itself." Nod reads and writes its own preferences
+            (personalization toggles, app-lock state, engine choice,
+            download preferences, crash-breaker flag). No UserDefaults
+            read or write touches another app's data.
+        -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+
+        <!--
+            File timestamp APIs (NSPrivacyAccessedAPICategoryFileTimestamp).
+            Reason C617.1: "Declare this reason to access the timestamps,
+            size, or other metadata of files inside the app container,
+            app group container, or the app's CloudKit container." Nod
+            calls FileManager.attributesOfItem(atPath:) in exactly two
+            places, both to read the .size attribute of downloaded model
+            files inside the app group container (used for download
+            integrity and progress checks):
+              - MLXModelSpec.swift:109
+              - MLXR2BackgroundSession.swift:333
+        -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Why

The V1 audit flagged this as the **single hard blocker** for App Store submission. Since May 2024, Apple rejects any iOS build that uses required-reason APIs without a privacy manifest. Nod is unsubmittable without it.

## What's declared

The manifest is minimal and accurate. It declares:

| Item | Value | Why |
|---|---|---|
| `NSPrivacyTracking` | `false` | Nod does not track users across apps or sites |
| `NSPrivacyTrackingDomains` | empty | No domains used for tracking |
| `NSPrivacyCollectedDataTypes` | empty | Nothing is collected — everything stays on-device |
| `NSPrivacyAccessedAPITypes` | 2 entries | Below |

### Required-reason APIs — the complete list for Nod

| Category | Reason code | Evidence |
|---|---|---|
| `NSPrivacyAccessedAPICategoryUserDefaults` | `CA92.1` (own app preferences) | 9 files use `UserDefaults` / `@AppStorage` — all for own-app state: personalization toggles, Face-ID lock preference, engine choice, download preferences, crash-breaker flag |
| `NSPrivacyAccessedAPICategoryFileTimestamp` | `C617.1` (files in app container) | Exactly 2 call sites of `FileManager.attributesOfItem(atPath:)`, both reading `.size` of downloaded model files inside the app group container: `MLXModelSpec.swift:109` and `MLXR2BackgroundSession.swift:333` |

**Not used** (verified by grep, no declaration needed): System boot time (`systemUptime`, `mach_absolute_time`), disk space APIs (`volumeAvailableCapacity`), active keyboard APIs (`UITextInputMode.activeInputModes`).

## Where the file lives

- **On disk:** `ios/Nod/PrivacyInfo.xcprivacy` (standard Apple convention)
- **In the bundle:** root-level (required by Apple's gate) — Xcode puts it there automatically when marked as a Resource
- **In pbxproj:** wired up as `PBXBuildFile` + `PBXFileReference` + added to the `Nod` group children + included in `PBXResourcesBuildPhase`
- **In project.yml:** auto-discovered via the existing `- path: Nod` source pattern, so future `xcodegen generate` keeps working

## How to verify after this merges

1. **Build the app** — no new compile steps; the manifest is pure config.
2. **In Xcode:** Product → Archive → Distribute App → **"Generate Privacy Report"**. The generated report should list:
   - Zero data collection
   - Two API uses: UserDefaults with reason CA92.1, File timestamps with reason C617.1
3. **Upload a dry-run build to TestFlight**. This is the only way to verify Apple's submission gate accepts the manifest — no human review involved at that stage, just the automated check.

## What's still open for V1 submission

This PR closes the **code-side** privacy manifest blocker. The remaining V1 submission work is in App Store Connect itself (not code):

- [ ] Draft App Store description, keywords, age rating
- [ ] Write App Review Notes explaining the 2.5 GB on-device model download
- [ ] Capture 6.9" + 6.1" iPhone screenshots
- [ ] Fill out Apple's privacy questionnaire in App Store Connect (should match this manifest: zero collection, zero tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>