### PR TITLE
docs: add OSS contribution scaffolding (contrib guide, CoC, security, templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,99 @@
+name: Bug report
+description: Something in Nod behaves wrong or crashes.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug.
+
+        **Before filing:** search existing issues to see if someone already reported this.
+
+        **Security problems:** do not file here. See [SECURITY.md](../SECURITY.md).
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of what went wrong.
+      placeholder: "I tapped the mic, spoke, and no text appeared in the input field."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+      placeholder: "Transcript appears in the input field within a second of tapping stop."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps that reliably trigger the problem. If you can't repro it consistently, say so.
+      placeholder: |
+        1. Open Nod on iPhone 16 Pro.
+        2. Tap the mic.
+        3. Speak for ~3 seconds.
+        4. Tap stop.
+        5. Nothing appears.
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device
+      description: iPhone model and iOS version.
+      placeholder: "iPhone 16 Pro, iOS 26.0.1"
+    validations:
+      required: true
+
+  - type: input
+    id: app-version
+    attributes:
+      label: Nod version
+      description: Visible in the sidebar footer ("Version 0.1.0 (21)").
+      placeholder: "0.1.0 (21)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: engine
+    attributes:
+      label: Which listening model was active?
+      description: You can find this in the sidebar under "Listening model".
+      options:
+        - "Apple Intelligence (AFM)"
+        - "Qwen 3 Instruct 2507"
+        - "Qwen 3.5 4B"
+        - "Gemma 4 E2B"
+        - "Don't know / not relevant"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs (optional)
+      description: |
+        Anything you've captured from Console.app filtered by subsystem `app.usenod.nod`.
+        Do not paste the content of any messages you wrote. Logs should contain only
+        technical diagnostics, never your personal text.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: privacy-check
+    attributes:
+      label: Privacy check
+      description: Double-check what you're about to post.
+      options:
+        - label: "I have not included personal journaling content in this report."
+          required: true
+        - label: "I have searched existing issues and this is not a duplicate."
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+# Disables the blank-issue option on GitHub's "New issue" page. Every
+# issue must go through one of the YAML templates (bug, feature) or
+# the Discussions contact link. Keeps the issue tracker focused.
+
+blank_issues_enabled: false
+
+contact_links:
+  - name: Ask a question
+    url: https://github.com/Speculative-Dynamics/nod/discussions
+    about: General questions, product discussions, "where should I start" → Discussions, not Issues.
+  - name: Report a security issue
+    url: https://github.com/Speculative-Dynamics/nod/security/advisories/new
+    about: Private vulnerability disclosure. Do not file security issues in the public tracker.
+  - name: Email the team
+    url: mailto:hello@usenod.app
+    about: For anything that doesn't fit the options above.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: Feature request
+description: Suggest a change or new capability.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature.
+
+        **Before filing:** read [CONTRIBUTING.md](../CONTRIBUTING.md) — specifically the "What we don't want" section. Nod deliberately avoids analytics, cloud sync, accounts, push notifications, and social features. Requests for these will be closed.
+
+        **Not sure if it fits?** Open a [Discussion](https://github.com/Speculative-Dynamics/nod/discussions) first.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Start with the user need, not the solution.
+      placeholder: "When I open Nod after a few days away, I can't easily find what I wrote last time."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Rough sketch of the solution. Screenshots or diagrams help.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other ways to solve this problem, and why you landed on the proposal.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: product-fit
+    attributes:
+      label: Product-fit check
+      description: Confirm this aligns with Nod's stance.
+      options:
+        - label: "This does not require cloud sync, accounts, or a server."
+          required: true
+        - label: "This does not collect analytics, telemetry, or any user data."
+          required: true
+        - label: "This does not add push notifications, reminders, or streaks."
+          required: true
+        - label: "I have searched existing issues and this is not a duplicate."
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,63 @@
+<!--
+  Thanks for opening a PR. Fill in the sections below so reviewers
+  can understand the change without having to read every line.
+
+  If any section is genuinely N/A, say so explicitly — don't delete it.
+-->
+
+## Summary
+
+<!-- 1-3 bullet points. What changed and why. -->
+
+-
+
+## Linked issue
+
+<!-- "Closes #123" auto-closes the issue on merge. "Refs #123" just links. -->
+
+Closes #
+
+## Type of change
+
+<!-- Pick one. Branch name should match (e.g., feat/short-desc → feat). -->
+
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `chore` — maintenance, deps, cleanup
+- [ ] `polish` — small UX / cosmetic improvement
+- [ ] `refactor` — restructure without behavior change
+- [ ] `docs` — documentation only
+- [ ] `ci` — CI config changes
+
+## Test plan
+
+<!--
+  How did you verify this works? Include the commands you ran and
+  what you saw. For UI changes: attach a screenshot or screen
+  recording. For bug fixes: describe the repro steps that now pass.
+-->
+
+- [ ]
+- [ ]
+
+## Screenshots / screen recordings
+
+<!-- Required for any UI change. Before/after if you can. -->
+
+## Privacy check
+
+<!-- Nod collects zero user data. Every PR touching network code or
+     persistence is checked against this line. -->
+
+- [ ] This change does not introduce any analytics, telemetry, tracking identifiers, or third-party SDKs.
+- [ ] This change does not cause user-written content to leave the device.
+- [ ] This change does not add unexpected network requests.
+
+## Checklist
+
+- [ ] Branch name matches the change type (e.g., `feat/voice-input`).
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`type: summary`).
+- [ ] CI passes (green check on this PR).
+- [ ] Code comments explain non-obvious decisions.
+- [ ] If I changed public behavior, I updated `CHANGELOG.md` under `[Unreleased]`.
+- [ ] If I added or renamed files, I updated `ios/README.md` if it references them.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant v2.1][cc] for community
+conduct.
+
+The short version: be kind, give people the benefit of the doubt,
+and give feedback on code rather than on people. We want a friendly
+place for new contributors to learn and ship.
+
+## Scope
+
+The Code of Conduct applies to all project spaces: this repository,
+GitHub Discussions, issues, pull requests, and any other official
+Nod channel. It also applies when you represent the project in
+public (talks, posts, demos).
+
+## Reporting
+
+If someone is making the community worse, let us know:
+[hello@usenod.app](mailto:hello@usenod.app). We will look at every
+report and respond. We will keep the reporter's identity private
+unless we have explicit permission to share it.
+
+For the full set of standards, enforcement steps, and attribution,
+read the [Contributor Covenant v2.1][cc] directly.
+
+[cc]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,216 @@
+# Contributing to Nod
+
+Thanks for wanting to help. Nod is an open-source iOS app for people
+who just want to be heard. It runs entirely on-device, collects no
+user data, and has no accounts. Those are the core constraints behind
+every decision here.
+
+This guide covers how to set up, what to work on, how we review, and
+the conventions we use.
+
+---
+
+## What we want help with
+
+If you are new to the project, the fastest way in is to pick up an
+issue labeled **[`good first issue`][gfi]** or **[`help wanted`][hw]**.
+
+[gfi]: https://github.com/Speculative-Dynamics/nod/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+[hw]: https://github.com/Speculative-Dynamics/nod/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
+
+High-value areas beyond those labels:
+
+- **Accessibility.** VoiceOver, Dynamic Type, keyboard navigation.
+  Mental-health apps have to be accessible. Audit any screen you use
+  and flag what breaks.
+- **Prompt quality.** The listening prompt lives at
+  [`prompts/listening_mode.md`](prompts/listening_mode.md). If you
+  have a fixture (an anonymized vent transcript) where Nod's reply
+  lands wrong, add it under [`ios/evals/listening-mode/`](ios/evals/listening-mode/)
+  and open an issue.
+- **New engine support.** New open-weight on-device models that fit
+  in 4-6 GB of RAM. Follow the pattern in
+  [`ios/Nod/Inference/MLXModelSpec.swift`](ios/Nod/Inference/MLXModelSpec.swift).
+- **Bug reports.** Concrete repro steps go a long way. Issue template
+  walks you through the details.
+
+What we **don't** want (already decided, not open for revisiting):
+
+- Analytics, telemetry, crash reporting SDKs. Nod collects zero data.
+  This is in the README for a reason.
+- Cloud sync, account systems, login flows. The local-only stance is
+  the product, not a limitation to fix.
+- Push notifications / reminders / streaks. Nod is calm by design.
+- Social features, sharing, community posts.
+
+If you're unsure whether an idea fits, open a Discussion before a PR.
+
+---
+
+## Getting set up
+
+Nod is a native SwiftUI iOS app targeting iOS 26+.
+
+**Requirements:**
+- macOS with **Xcode 16+** (Xcode 26 recommended for the iOS 26 SDK)
+- Apple Developer account (Personal tier is fine for local installs)
+- An **iPhone 15 Pro or later** for on-device testing
+- Apple Intelligence enabled in Settings → Apple Intelligence & Siri
+
+**Build and run:**
+
+```bash
+git clone git@github.com:Speculative-Dynamics/nod.git
+cd nod/ios
+open Nod.xcodeproj
+```
+
+In Xcode: select your iPhone as the destination, pick your Team
+under Signing & Capabilities on the `Nod` target, then Cmd+R.
+
+For the full layout, build flags, and architecture tour, see
+[`ios/README.md`](ios/README.md). For a repo-wide overview of
+`ios/`, `website/`, and `prompts/`, see
+[`ARCHITECTURE.md`](ARCHITECTURE.md).
+
+**XcodeGen:** `ios/project.yml` is the source of truth. `Nod.xcodeproj`
+is committed so a fresh clone builds without installing XcodeGen.
+If you edit `project.yml`, regenerate with `cd ios && xcodegen generate`.
+
+---
+
+## How to submit a change
+
+### 1. Pick or file an issue first
+
+For anything bigger than a typo or a one-line fix, open or claim an
+issue before writing code. This avoids wasted work if the scope or
+approach needs discussion.
+
+### 2. Branch naming
+
+We use conventional prefixes so the branch name tells you what's in it:
+
+- `feat/short-description` — new feature
+- `fix/short-description` — bug fix
+- `chore/short-description` — maintenance, deps, cleanup
+- `polish/short-description` — small UX/cosmetic improvements
+- `refactor/short-description` — restructure without changing behavior
+- `docs/short-description` — documentation
+- `ci/short-description` — CI config changes
+
+Examples: `fix/keyboard-after-dictation`, `feat/cellular-download-toggle`.
+
+### 3. Write the code
+
+Keep diffs focused. One concern per PR. If you end up touching more
+than 8 files, stop and ask whether the work should be split.
+
+**Swift style:**
+- Strict concurrency (`SWIFT_STRICT_CONCURRENCY=complete`) is on.
+  Respect `@MainActor`, `Sendable`, and actor isolation. Don't add
+  `@unchecked Sendable` without a comment explaining why.
+- Comments explain **why**, not what. The code already says what.
+- ASCII diagrams in code comments for non-trivial state machines or
+  pipelines are encouraged. Update them in the same PR when the code
+  changes.
+- No emojis in source files unless explicitly requested.
+
+**Things to avoid:**
+- Force-unwraps (`!`) on user input or network results.
+- `try!` outside of previews and "cannot fail" init paths.
+- Logging user content. Don't print what the user wrote, ever — not
+  in Console.app, not in analytics (we don't have any anyway).
+- New third-party SDKs. MLX, GRDB, and swift-transformers are the
+  only runtime dependencies. Additions need a strong case.
+
+### 4. Commit messages
+
+Use conventional commits:
+
+```
+type: short imperative summary
+
+Optional longer body explaining why (not what) and any tradeoffs.
+```
+
+Types match branch prefixes: `feat`, `fix`, `chore`, `polish`,
+`refactor`, `docs`, `ci`.
+
+### 5. Open a pull request
+
+The PR template will walk you through what to include. At minimum:
+
+- Summary (1-3 bullets)
+- Test plan (how you verified it works)
+- Screenshots or screen recordings for UI changes
+
+Our CI runs `xcodebuild` against the iPhone 17 Pro Simulator on
+every PR. If your branch doesn't build locally, it won't build in
+CI either — run the build before pushing.
+
+### 6. Review
+
+We try to respond within a few days. We don't currently have SLAs,
+and this is a small team, so please be patient.
+
+What reviewers look for:
+
+- Does this belong in Nod? (See "What we don't want" above.)
+- Is the diff minimal? Could this be simpler?
+- Does it preserve the no-data-collection guarantee? (If it touches
+  network code, this is the top question.)
+- Does it work on-device, not just in Preview?
+- Does it respect accessibility (VoiceOver, Dynamic Type)?
+
+If a change needs redirection, we'll say so plainly. Not personal,
+just trying to keep the product tight.
+
+---
+
+## Testing
+
+There is no unit-test target in the iOS app yet — documented in the
+[V1 audit](CHANGELOG.md) as a known gap. For now, testing means:
+
+- **Build verification:** CI runs `xcodebuild` on every PR. Green
+  check means at least it compiles.
+- **Manual device testing:** run on your iPhone 15 Pro+. Walk the
+  flows your change touches. For UI work, test light + dark mode.
+- **Eval fixtures:** prompt changes should be tested against
+  [`ios/evals/listening-mode/`](ios/evals/listening-mode/). Add your
+  own fixture if your change exercises a pattern we don't cover.
+
+A proper test target is on the roadmap. If you want to contribute
+that, open a discussion first — we'll need to decide on Swift Testing
+vs XCTest, and what to test first.
+
+---
+
+## Reporting security issues
+
+**Do not file security issues as public GitHub issues.**
+
+See [`SECURITY.md`](SECURITY.md) for the responsible disclosure
+process.
+
+---
+
+## Code of conduct
+
+By participating, you agree to follow our
+[Code of Conduct](CODE_OF_CONDUCT.md). The short version: be kind,
+assume good intent, give feedback on code not people. Mental-health
+adjacent projects attract vulnerable users and new contributors —
+we take this seriously.
+
+---
+
+## Questions
+
+- **Anything non-confidential:** open a [Discussion](https://github.com/Speculative-Dynamics/nod/discussions).
+- **Bug reports / feature requests:** use the [Issue templates](https://github.com/Speculative-Dynamics/nod/issues/new/choose).
+- **Security:** [`SECURITY.md`](SECURITY.md).
+- **General:** [hello@usenod.app](mailto:hello@usenod.app).
+
+Thank you for reading this far. We're genuinely glad you're here.

--- a/README.md
+++ b/README.md
@@ -104,11 +104,30 @@ A link to the App Store listing will appear at
 .
 ├── ios/          Native iOS app — see ios/README.md for build instructions
 ├── website/      Marketing site at usenod.app
+├── prompts/      LLM prompts, shared across platforms
 └── LICENSE       MIT
 ```
 
 For the iOS app's internal architecture, build steps, and engineering
-notes, see [`ios/README.md`](ios/README.md).
+notes, see [`ios/README.md`](ios/README.md). For a repo-wide overview,
+see [`ARCHITECTURE.md`](ARCHITECTURE.md).
+
+## Contributing
+
+We welcome contributions. Quickest way in:
+
+- Pick up an issue labeled [`good first issue`](https://github.com/Speculative-Dynamics/nod/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+  or [`help wanted`](https://github.com/Speculative-Dynamics/nod/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+- Read [`CONTRIBUTING.md`](CONTRIBUTING.md) for setup, branch
+  conventions, what we're looking for, and what we've decided not
+  to build.
+- Have a question before filing an issue? Open a
+  [Discussion](https://github.com/Speculative-Dynamics/nod/discussions).
+- Found a security issue? See [`SECURITY.md`](SECURITY.md) — do not
+  file security problems as public issues.
+
+By participating, you agree to follow our
+[Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Who built this
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policy
+
+Nod stores a user's private journal on-device. If you find a way to
+expose that data, compromise the app, or break any of the privacy
+guarantees in the [README](README.md) or at
+[usenod.app/privacy](https://usenod.app/privacy), we want to know
+before anyone else does.
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security problems.**
+
+Email [security@usenod.app](mailto:security@usenod.app) with:
+
+- A short description of the issue.
+- Steps to reproduce, or a proof-of-concept.
+- What an attacker could do (impact assessment, even informal).
+- Your name or handle if you want credit; we can keep it anonymous.
+
+Alternatively, use GitHub's private
+[Security Advisories](https://github.com/Speculative-Dynamics/nod/security/advisories/new)
+form to file a private report.
+
+## What happens next
+
+- **Within 72 hours:** we acknowledge your report.
+- **Within 7 days:** we confirm the issue or explain why we think it
+  is not a security problem.
+- **Timeline to fix:** depends on severity. Critical issues (exposure
+  of user data, account takeover, remote code execution) get
+  prioritized above all other work.
+- **Disclosure:** we coordinate public disclosure with you. We aim
+  for responsible disclosure within 90 days of confirmation, sooner
+  if a fix is already shipped.
+
+## Scope
+
+**In scope:**
+- The iOS app (`ios/`)
+- The marketing website (`website/`)
+- Any issue where Nod behaves differently from its privacy claims
+  (data leaving the device, identifiers sent to third parties,
+  anything that breaks the "nothing is collected" promise)
+
+**Out of scope:**
+- Social-engineering attacks on the maintainers
+- Physical attacks on a user's device
+- Issues in third-party dependencies that we forward upstream
+- Vulnerabilities requiring a jailbroken device
+
+## Recognition
+
+We are a small indie project and cannot offer a bug bounty. We will
+credit you in the release notes for the fix (with your permission)
+and in the [`CHANGELOG.md`](CHANGELOG.md).
+
+Thank you for helping keep Nod users safe.


### PR DESCRIPTION
## Why

Second PR in the OSS-readiness rollout. The iOS CI workflow landed first (PR #10) so `CONTRIBUTING.md` can honestly promise "every PR gets a green check automatically." This PR makes that promise and spells out the rest of the contribution path.

## What's in this PR

| File | Purpose |
|---|---|
| `CONTRIBUTING.md` | Setup, branch naming, Swift style rules, review expectations, explicit "what we don't want" list (analytics, cloud sync, accounts, push, social). ~200 lines. |
| `CODE_OF_CONDUCT.md` | Links canonical Contributor Covenant v2.1 with short in-repo summary and a reporter contact. |
| `SECURITY.md` | Private disclosure via `security@usenod.app` or GitHub Security Advisories. 72h ack, 7d triage, 90d disclosure. Explicit scope includes privacy guarantees (data leaving the device = security issue). |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Repro + device + engine + privacy-check checklist. |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | Product-fit checklist that pre-empts out-of-scope asks before review. |
| `.github/ISSUE_TEMPLATE/config.yml` | Disables blank-issue, redirects general questions to Discussions. |
| `.github/PULL_REQUEST_TEMPLATE.md` | Summary / test plan / screenshots / privacy check / conventional-commit checklist. |
| `README.md` | New Contributing section pointing at all of the above plus label filters. Adds `prompts/` to repo layout. |

## Manual setup required before this is fully live

- [ ] **Set up `security@usenod.app` mail alias** — the SECURITY.md flow depends on it. Route to the same inbox as `hello@usenod.app` for now if you want.
- [ ] **Enable Discussions** on the repo (Settings → General → Features → Discussions). The issue-template `config.yml` links to Discussions for general questions.
- [ ] **Set repo topics** for discoverability: `ios`, `swift`, `ai`, `on-device`, `mlx`, `open-source`, `journaling`.
- [ ] **Enable Security Advisories** for private vulnerability reporting (Settings → Code security → Private vulnerability reporting → Enable).

These four are GitHub Settings toggles / mail-alias work, not code — easier to do in the UI than via API.

## What's not in this PR

- `ARCHITECTURE.md` at repo root — coming in the next PR along with curated "good first issue" labels.

## Test plan
- [ ] After merge, visit https://github.com/Speculative-Dynamics/nod/issues/new/choose and verify the three template options appear (Bug, Feature, Contact Links)
- [ ] Open a draft PR and verify the PR template autofills
- [ ] Send a test email to `security@usenod.app` and confirm it reaches the inbox (after the alias is set up)
- [ ] Click every link in the new README Contributing section and verify none 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>