### PR TITLE
fix(copy): correct the engine story — AFM default, MLX optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,15 @@ architecturally incapable of leaking a single word of what you say.
 ### It runs entirely on your phone
 
 No servers. No accounts. No API keys. No login. Every word you type stays
-on the device. The listening model (**Qwen 3.5 4B**) runs on-device via
-MLX Swift. Memory and summaries are handled by Apple's own on-device LLM
-(**FoundationModels**, part of Apple Intelligence).
+on the device, read only by a model running on the same chip. Out of the
+box, that model is Apple's own on-device LLM — **FoundationModels**, part
+of Apple Intelligence. Nothing to download. It just works.
+
+If you'd rather run an open-weights model on your phone, open settings and
+switch the engine to **Qwen 3 Instruct 2507**, **Qwen 3.5 4B**, or
+**Gemma 4 E2B** — all via MLX Swift. When you switch for the first time,
+Nod downloads the weights (2–3 GB, Wi-Fi by default) once via Apple's
+Background Assets framework. After that, inference is fully offline.
 
 We don't see what you write. **No one does.** Not because we promise —
 because there is no pipe to send it through.
@@ -91,9 +97,11 @@ the model. Here's a piece of it:
 Nod will be listed on the App Store as **Just Nod** — the name *Nod*
 alone was taken, and besides, it matches the in-app button.
 
-Requires an iPhone with Apple Intelligence — **iOS 26.0 or later**. On
-first launch, the app downloads the Qwen model weights (~2.5 GB) once via
-Apple's Background Assets framework. After that, it works fully offline.
+Requires an iPhone with Apple Intelligence — **iOS 26.0 or later**. Works
+instantly on Apple's on-device model — no extra download needed. If you
+switch to an open-weights engine (Qwen or Gemma via MLX) in settings,
+Nod downloads the selected model once (2–3 GB, Wi-Fi only by default).
+Otherwise, nothing is downloaded; nothing leaves the device.
 
 A link to the App Store listing will appear at
 [usenod.app](https://usenod.app) once the app ships.

--- a/website/index.html
+++ b/website/index.html
@@ -154,7 +154,7 @@
                         "@id": "https://usenod.app/#app",
                         "name": "Just Nod",
                         "alternateName": "Nod",
-                        "description": "A small on-device AI that listens without fixing. Runs entirely on your iPhone via Apple Intelligence and Qwen 3.5 4B through MLX Swift. No servers, no accounts, no tracking.",
+                        "description": "A small on-device AI that listens without fixing. Runs on Apple Intelligence out of the box, or switch to an open-weights engine — Qwen 3, Qwen 3.5, or Gemma 4 via MLX Swift — in settings. No servers, no accounts, no tracking.",
                         "applicationCategory": "HealthApplication",
                         "operatingSystem": "iOS 26.0",
                         "url": "https://usenod.app/",
@@ -290,23 +290,38 @@
 
                     <ul class="facts">
                         <li>
-                            <span class="facts__key">Listening model</span>
-                            <span class="facts__val">Qwen 3.5 4B</span>
-                            <span class="facts__note"
-                                >Running on-device via MLX Swift. Downloaded
-                                once, stays on your phone.</span
-                            >
-                        </li>
-                        <li>
-                            <span class="facts__key"
-                                >Memory &amp; summaries</span
-                            >
+                            <span class="facts__key">Default engine</span>
                             <span class="facts__val"
                                 >Apple FoundationModels</span
                             >
                             <span class="facts__note"
-                                >Apple Intelligence's on-device LLM. Never sees
-                                a network.</span
+                                >Apple Intelligence's on-device LLM. Runs the
+                                second you open the app — no download, no
+                                network.</span
+                            >
+                        </li>
+                        <li>
+                            <span class="facts__key">Alternative engines</span>
+                            <span class="facts__val"
+                                >Qwen 3, Qwen 3.5, Gemma 4</span
+                            >
+                            <span class="facts__note"
+                                >Open-weights models via MLX Swift. Switch in
+                                settings — Nod downloads the selected model
+                                once (2&ndash;3&nbsp;GB, Wi-Fi by default),
+                                then runs on-device forever.</span
+                            >
+                        </li>
+                        <li>
+                            <span class="facts__key">Memory</span>
+                            <span class="facts__val"
+                                >On-device fact extraction</span
+                            >
+                            <span class="facts__note"
+                                >Apple FoundationModels extracts structured
+                                memories from each turn. Browse them in the
+                                sidebar; delete any one of them, or all of
+                                them.</span
                             >
                         </li>
                         <li>
@@ -446,8 +461,11 @@
                         <p class="download-box__meta">
                             Requires iPhone with Apple Intelligence — iOS 26.0
                             or later.<br />
-                            Roughly 2.5 GB for the on-device model, downloaded
-                            once on first launch.
+                            Works instantly on Apple's on-device model. If you
+                            later switch to an open-weights engine
+                            (Qwen or Gemma via MLX) in settings, Nod downloads
+                            the selected model once — 2–3&nbsp;GB, Wi-Fi by
+                            default.
                         </p>
                     </div>
                 </div>

--- a/website/privacy/index.html
+++ b/website/privacy/index.html
@@ -136,16 +136,27 @@
                     </p>
                     <ul>
                         <li>
-                            The <strong>listening model</strong> (Qwen 3.5 4B)
-                            runs on-device via MLX Swift. Your prompts never
-                            leave the phone.
+                            The <strong>default listening model</strong> is
+                            Apple's on-device LLM —
+                            <code>FoundationModels</code>, part of Apple
+                            Intelligence. It runs on the same chip that the app
+                            is installed on and does not make network requests.
+                            Your prompts never leave the phone.
                         </li>
                         <li>
-                            The <strong>memory and summaries</strong> feature
-                            uses Apple's on-device
-                            <code>FoundationModels</code> framework (part of
-                            Apple Intelligence). It runs on the same chip; it
-                            does not make network requests.
+                            You can <strong>optionally switch</strong> to an
+                            open-weights model in settings — Qwen 3 Instruct
+                            2507, Qwen 3.5 4B, or Gemma 4 E2B Text, all served
+                            via MLX Swift. These also run on-device. Choosing
+                            one triggers a one-time weights download (see
+                            below); after that, inference stays on the phone.
+                        </li>
+                        <li>
+                            The <strong>memory</strong> feature uses
+                            <code>FoundationModels</code> to extract structured
+                            facts from each turn, stored locally for the
+                            sidebar's "what Nod remembers" view. You can purge
+                            individual facts or everything.
                         </li>
                         <li>
                             Your <strong>conversation history</strong> is stored
@@ -155,8 +166,8 @@
                         </li>
                         <li>
                             Tapping <strong>"Start fresh"</strong> permanently
-                            deletes your local conversation on that device. This
-                            is irreversible.
+                            deletes your local conversation, running summary,
+                            and memory on that device. This is irreversible.
                         </li>
                     </ul>
                     <p>
@@ -168,13 +179,21 @@
                         backup system under your Apple account settings.
                     </p>
 
-                    <h3>Required network activity</h3>
+                    <h3>Optional network activity</h3>
                     <p>
-                        There is one unavoidable network event: on first launch,
-                        the app downloads the Qwen model weights (~2.5 GB) from
-                        Nod's hosted model files. This is a one-time download.
-                        After that, the app functions fully offline. We don't
-                        receive your conversation content as part of this
+                        On the default Apple Intelligence engine, the app does
+                        not download anything and makes no network requests
+                        related to your conversation.
+                    </p>
+                    <p>
+                        If you switch to an open-weights engine (Qwen 3 / 3.5
+                        or Gemma 4) in settings, Nod downloads the selected
+                        model's weights (~2–3 GB) one time from our hosted
+                        model files on Cloudflare R2 via Apple's Background
+                        Assets framework. Downloads default to Wi-Fi only; you
+                        can opt into cellular. After the weights are on your
+                        device, the app functions fully offline. We do not
+                        receive any conversation content as part of this
                         download.
                     </p>
 


### PR DESCRIPTION
## Summary
Previous copy made it sound like Qwen was the default listening engine and downloaded on first launch. That's reversed. Real behavior:

- **Default on install:** Apple FoundationModels (Apple Intelligence). No download, no network. Works immediately.
- **Optional:** switch to Qwen 3 Instruct 2507, Qwen 3.5 4B, or Gemma 4 E2B (via MLX Swift) in settings. Switching triggers a one-time 2–3 GB weights download from Cloudflare R2 via Background Assets, Wi-Fi by default.

## Changes
- **README.md** — rewrote the "runs entirely on your phone" paragraph and the "Getting it" download requirements.
- **website/index.html** — updated JSON-LD MobileApplication description, the facts grid (new rows: Default engine, Alternative engines, Memory), and the download-box meta line.
- **website/privacy/index.html** — split the listening-model bullet into default + optional, added memory bullet, rewrote "Required network activity" section as "Optional network activity" reflecting that the download only happens if the user switches engines.

## Test plan
- [ ] Review the rewrite on / and /privacy/
- [ ] Merge when happy
- [ ] Pages workflow auto-redeploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)