### PR TITLE
[codex] Prepare production cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://usenod.app"><strong>usenod.app</strong></a> &nbsp;·&nbsp;
-  <a href="https://apps.apple.com/us/app/">App Store</a> &nbsp;·&nbsp;
+  App Store coming soon &nbsp;·&nbsp;
   <a href="LICENSE">MIT License</a>
 </p>
 

--- a/ios/Nod/Inference/EntityExtractorService.swift
+++ b/ios/Nod/Inference/EntityExtractorService.swift
@@ -55,9 +55,11 @@ final class EntityExtractorService {
     /// Run extraction on a batch of messages. Tries AFM first, falls back
     /// to the active engine, returns empty on total failure. Never throws.
     func extract(from messages: [Message]) async -> ExtractedEntities {
+        log.info("extract: starting with \(messages.count, privacy: .public) messages (primary=\(self.primary != nil, privacy: .public))")
         if let primary {
             do {
                 let result = try await primary.extractEntities(from: messages)
+                log.info("extract: AFM returned \(result.items.count, privacy: .public) items — \(result.items.map(\.name).joined(separator: ", "), privacy: .public)")
                 return result
             } catch let error as LanguageModelSession.GenerationError {
                 // AFM refused (guardrailViolation is the common one) or hit
@@ -81,7 +83,9 @@ final class EntityExtractorService {
             return ExtractedEntities(items: [])
         }
         do {
-            return try await fallback.extractEntities(from: messages)
+            let result = try await fallback.extractEntities(from: messages)
+            log.info("extract: fallback returned \(result.items.count, privacy: .public) items — \(result.items.map(\.name).joined(separator: ", "), privacy: .public)")
+            return result
         } catch {
             log.warning("Fallback extraction failed: \(String(describing: error), privacy: .public); returning empty")
             return ExtractedEntities(items: [])

--- a/ios/Nod/Storage/ConversationStore.swift
+++ b/ios/Nod/Storage/ConversationStore.swift
@@ -12,7 +12,13 @@
 // message is sent to the LLM as full-fidelity context.
 
 import Foundation
+import OSLog
 import SwiftUI
+
+/// Diagnostic logger for conversation + memory pipeline events. Shared
+/// category with EntityStore so `category:memory` in Console surfaces
+/// the full trigger → extract → ingest → persist sequence in one stream.
+private let memoryLog = Logger(subsystem: "app.usenod.nod", category: "memory")
 
 @MainActor
 final class ConversationStore: ObservableObject {
@@ -416,11 +422,13 @@ final class ConversationStore: ObservableObject {
             self.summary = resolvedSummary
             // Now async — precomputes embeddings off-main, applies state
             // changes on-main. See EntityStore.ingest(_:) for detail.
+            memoryLog.info("compression: ingesting \(resolvedExtracted.items.count, privacy: .public) extracted items from batch of \(oldest.count, privacy: .public)")
             await self.entityStore.ingest(resolvedExtracted)
         } catch {
             // Compression is best-effort — if it fails this pass, the
             // un-summarized backlog grows by one batch and we retry on
             // the next high-water trip. The conversation keeps working.
+            memoryLog.error("compression: pass failed — \(String(describing: error), privacy: .public)")
         }
     }
 
@@ -440,9 +448,11 @@ final class ConversationStore: ObservableObject {
     ///     in-flight when the app was killed
     private func maybeRunIncrementalExtraction() {
         if incrementalExtractionTask != nil {
+            memoryLog.info("incremental: trigger coalesced — task already running")
             extractionWantsRerun = true
             return
         }
+        memoryLog.info("incremental: scheduling extraction task")
         incrementalExtractionTask = Task.detached(priority: .utility) { [weak self] in
             await self?.runIncrementalExtraction()
         }
@@ -459,21 +469,28 @@ final class ConversationStore: ObservableObject {
                 // catch-up pass. The new task will re-check the DB for
                 // any still-unextracted rows.
                 if shouldRerun {
+                    memoryLog.info("incremental: rerun requested, scheduling catch-up")
                     self.maybeRunIncrementalExtraction()
                 }
             }
         }
         do {
             let batch = try database.fetchUnextractedMessages(limit: INCREMENTAL_EXTRACTION_WINDOW)
-            guard !batch.isEmpty else { return }
+            guard !batch.isEmpty else {
+                memoryLog.info("incremental: no unextracted messages, skipping")
+                return
+            }
+            memoryLog.info("incremental: processing \(batch.count, privacy: .public) unextracted messages")
             await extractAndIngest(messages: batch)
             try database.markEntitiesExtracted(ids: batch.map(\.id))
+            memoryLog.info("incremental: marked \(batch.count, privacy: .public) messages as extracted")
         } catch {
             // Best-effort. If this pass fails, the watermark column stays
             // NULL for the batch and the next trigger retries them. The
             // compression pass (running at the 12-message mark via
             // markCompressed) is the backstop that prevents permanent
             // loss if incremental keeps failing.
+            memoryLog.error("incremental: pass failed — \(String(describing: error), privacy: .public)")
         }
     }
 

--- a/ios/Nod/Storage/EntityStore.swift
+++ b/ios/Nod/Storage/EntityStore.swift
@@ -616,7 +616,9 @@ final class EntityStore: ObservableObject {
         do {
             try database.upsertEntity(entity)
             entities[index] = entity
+            memoryLog.info("persistAndCache: updated entity \(entity.canonicalName, privacy: .public) (mentionCount=\(entity.mentionCount, privacy: .public))")
         } catch {
+            memoryLog.error("persistAndCache: upsertEntity threw for \(entity.canonicalName, privacy: .public): \(String(describing: error), privacy: .public)")
             // DB write failed. `entities[index]` still holds the old
             // version. The caller (updateExisting / resolve) has
             // already applied the new vector to the cache via

--- a/ios/Nod/Storage/EntityStore.swift
+++ b/ios/Nod/Storage/EntityStore.swift
@@ -24,7 +24,15 @@
 // lines of real logic.
 
 import Foundation
+import OSLog
 import SwiftUI
+
+/// Diagnostic logger for entity persistence. Surfaces insert/load counts
+/// so we can tell whether entities are being written, whether they're
+/// being read back, and — if they silently vanish — which side of the
+/// boundary dropped them. Filter in Console.app with
+/// `subsystem:app.usenod.nod category:memory`.
+private let memoryLog = Logger(subsystem: "app.usenod.nod", category: "memory")
 
 @MainActor
 final class EntityStore: ObservableObject {
@@ -128,11 +136,29 @@ final class EntityStore: ObservableObject {
         guard !isHydrated else { return }
 
         let db = self.database
-        let fetched: [Entity] = await Task.detached {
-            (try? db.fetchAllEntities()) ?? []
+        // Fetch runs off-main. If GRDB throws, we surface the specific
+        // error so "memories disappeared on relaunch" bug reports can be
+        // diagnosed from Console — without the log we'd silently coerce
+        // to [] via `try?` and the root cause would be invisible.
+        //
+        // Log both the raw row count AND the decoded entity count. If
+        // the DB has rows but fetchAllEntities returns fewer, the
+        // decoder is dropping them — a different bug than "entities
+        // weren't persisted at all."
+        let (rawCount, fetched): (Int, [Entity]) = await Task.detached {
+            let rawCount = (try? db.entitiesRowCount()) ?? -1
+            let entities: [Entity]
+            do {
+                entities = try db.fetchAllEntities()
+            } catch {
+                memoryLog.error("hydrate: fetchAllEntities threw \(String(describing: error), privacy: .public)")
+                entities = []
+            }
+            return (rawCount, entities)
         }.value
 
         self.entities = fetched
+        memoryLog.info("hydrate: DB rows=\(rawCount, privacy: .public), decoded entities=\(fetched.count, privacy: .public)")
         // Populate decoded-embedding cache. See the invariant note above
         // `decodedEmbeddings`. This is the only place we pay the N-decode
         // cost; every subsequent retrieval reads the cached vectors.
@@ -259,6 +285,7 @@ final class EntityStore: ObservableObject {
         // On-main: apply dedup + insert logic, using precomputed embeddings.
         // This is the same control flow as the pre-async version; the only
         // substitution is `item.embedding` instead of `embedder.embed(...)`.
+        memoryLog.info("ingest: \(precomputed.count, privacy: .public) candidates (existing entities=\(self.entities.count, privacy: .public))")
         for item in precomputed {
             guard let type = EntityType(rawValue: item.rawType.lowercased()) else {
                 continue  // LLM returned an unknown type; skip.
@@ -267,6 +294,7 @@ final class EntityStore: ObservableObject {
 
             // Exact or alias match → update in place.
             if let existingIdx = findExactMatch(name: item.name) {
+                memoryLog.info("ingest: \(item.name, privacy: .public) → exact/alias match, updateExisting")
                 updateExisting(at: existingIdx, newRole: item.role, newNote: item.note)
                 continue
             }
@@ -302,6 +330,7 @@ final class EntityStore: ObservableObject {
                 // Don't persist the candidate yet — it's pending the
                 // user's [Same/New] answer. If they pick [Same] we add
                 // the alias; [New] we insert fresh.
+                memoryLog.info("ingest: \(item.name, privacy: .public) → fuzzy match with \(fuzzy.canonicalName, privacy: .public), queued for disambiguation (NOT persisted)")
                 let pending = PendingDisambiguation(
                     candidate: candidateWithEmbedding,
                     existing: fuzzy
@@ -567,6 +596,7 @@ final class EntityStore: ObservableObject {
         do {
             try database.upsertEntity(entity)
             entities.append(entity)
+            memoryLog.info("insertFresh: persisted entity \(entity.canonicalName, privacy: .public) (type: \(entity.type.rawValue, privacy: .public))")
         } catch {
             // DB write failed — keep the in-memory state consistent
             // with disk by NOT updating the cache, and silently drop
@@ -578,6 +608,7 @@ final class EntityStore: ObservableObject {
             // the entity won't exist in `entities`, drop the orphaned
             // cache entry to preserve the invariant.
             decodedEmbeddings.removeValue(forKey: entity.id)
+            memoryLog.error("insertFresh: upsertEntity threw for \(entity.canonicalName, privacy: .public): \(String(describing: error), privacy: .public)")
         }
     }
 

--- a/ios/Nod/Storage/MessageDatabase.swift
+++ b/ios/Nod/Storage/MessageDatabase.swift
@@ -252,6 +252,16 @@ final class MessageDatabase: @unchecked Sendable {
         }
     }
 
+    /// Diagnostic: raw row count in the entities table. Bypasses the
+    /// entityFromRow decoder (which can drop rows if parsing fails) so
+    /// we can tell "row in DB" from "row in in-memory array". Used by
+    /// EntityStore.hydrate to surface persistence-layer bugs.
+    func entitiesRowCount() throws -> Int {
+        try queue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM entities") ?? 0
+        }
+    }
+
     /// Un-summarized messages only, oldest first. Used to build the context
     /// window for the LLM (summary + these).
     func fetchUnsummarizedMessages() throws -> [Message] {

--- a/ios/Nod/Views/SidebarView.swift
+++ b/ios/Nod/Views/SidebarView.swift
@@ -282,6 +282,11 @@ struct SidebarView: View {
                         Link(destination: url) {
                             Label("Send feedback", systemImage: "envelope")
                         }
+                        // Link defaults to the accent tint. Override to
+                        // primary text color so this row matches "Start
+                        // fresh" and other action rows — the orange icon
+                        // alone is enough visual signal.
+                        .foregroundStyle(.primary)
                     } else {
                         // URLComponents couldn't assemble a valid mailto
                         // (extremely unlikely — shouldn't happen in practice).

--- a/website/README.md
+++ b/website/README.md
@@ -4,28 +4,28 @@ Marketing and landing page for the Nod iOS app. Domain: [usenod.app](https://use
 
 ## Status
 
-Not started. Will be built after the iOS app's Phase 1 is shipping to TestFlight. Revisit then.
+Live static site in this directory. It is intentionally plain HTML, CSS, and a
+small amount of vanilla JavaScript so it can be deployed without a build step.
 
-## Likely shape
+## Shape
 
-Single-page static site. Framework TBD — candidates:
+The homepage is a single-page marketing site, with separate static legal pages:
 
-- **Astro** (nice default for content sites, fast, minimal JS)
-- **Plain HTML/CSS** (least tooling, ships instantly)
-- **Next.js** (overkill for a one-pager, but familiar)
+- `index.html`
+- `privacy/index.html`
+- `terms/index.html`
 
-Hosting: probably Cloudflare Pages or Vercel (free tier is plenty for a solo side project).
+Hosting can be any static host. The current domain target is
+[usenod.app](https://usenod.app).
 
-## What it needs
+## Deployment checklist
 
-- A clear statement of what Nod is ("For when you just need to be heard.")
-- The Nod face
-- A TestFlight / App Store download link
-- A link to the GitHub repo
-- A privacy statement that doesn't lie ("Nod runs entirely on your phone. We can't see your words because we have no server.")
-
-That's it. No pricing page, no testimonials, no feature grid.
+- Replace the App Store "coming soon" state with the real listing URL once the
+  app is approved.
+- Keep `sitemap.xml`, canonical links, Open Graph image URLs, and `CNAME`
+  aligned to `https://usenod.app`.
+- Validate `manifest.webmanifest` and `script.js` before publishing.
 
 ## License
 
-The website code, once it exists, will share the repo's MIT license.
+The website code shares the repo's MIT license.

--- a/website/index.html
+++ b/website/index.html
@@ -23,7 +23,7 @@
         <title>Nod — For when you just need to be heard.</title>
         <meta
             name="description"
-            content="A small on-device AI that listens without fixing. Runs entirely on your iPhone. No servers, no accounts, no tracking. Open source. Listed on the App Store as Just Nod."
+            content="A small on-device AI that listens without fixing. Runs entirely on your iPhone. No servers, no accounts, no tracking. Open source. Coming soon to the App Store as Just Nod."
         />
         <meta
             name="keywords"
@@ -159,7 +159,6 @@
                         "applicationCategory": "HealthApplication",
                         "operatingSystem": "iOS 26.0",
                         "url": "https://usenod.app/",
-                        "downloadUrl": "https://apps.apple.com/us/app/",
                         "image": "https://usenod.app/assets/og-image.jpg",
                         "author": { "@id": "https://usenod.app/#organization" },
                         "offers": {
@@ -637,7 +636,7 @@
                             class="btn btn--ghost"
                             href="https://github.com/Speculative-Dynamics/nod"
                             target="_blank"
-                            rel="noopener"
+                            rel="noopener noreferrer"
                         >
                             <span class="btn__arrow">→</span> View on GitHub
                         </a>
@@ -645,7 +644,7 @@
                             class="btn btn--ghost"
                             href="https://github.com/Speculative-Dynamics/nod/blob/main/LICENSE"
                             target="_blank"
-                            rel="noopener"
+                            rel="noopener noreferrer"
                         >
                             <span class="btn__arrow">→</span> Read the license
                         </a>
@@ -662,7 +661,7 @@
                 <div class="container">
                     <p class="eyebrow">It's free.</p>
                     <h2 class="display">
-                        Listed as <em>Just Nod</em><br />
+                        Coming soon as <em>Just Nod</em><br />
                         on the App Store.
                     </h2>
                     <div class="body">
@@ -673,12 +672,10 @@
                     </div>
 
                     <div class="download-box">
-                        <a
-                            href="https://apps.apple.com/us/app/"
-                            target="_blank"
-                            rel="noopener"
-                            class="appstore-btn"
-                            data-appstore
+                        <span
+                            class="appstore-btn appstore-btn--disabled"
+                            role="status"
+                            aria-label="App Store listing coming soon"
                         >
                             <svg
                                 viewBox="0 0 40 40"
@@ -692,10 +689,10 @@
                                 />
                             </svg>
                             <span class="appstore-btn__text">
-                                <small>Download on the</small>
+                                <small>Coming soon on the</small>
                                 <strong>App Store</strong>
                             </span>
-                        </a>
+                        </span>
                         <p class="download-box__meta">
                             Requires iPhone with Apple Intelligence — iOS 26.0
                             or later.<br />
@@ -727,13 +724,13 @@
                             <a
                                 href="https://github.com/Speculative-Dynamics/nod"
                                 target="_blank"
-                                rel="noopener"
+                                rel="noopener noreferrer"
                                 >GitHub</a
                             >
                             <a
                                 href="https://github.com/Speculative-Dynamics/nod/blob/main/LICENSE"
                                 target="_blank"
-                                rel="noopener"
+                                rel="noopener noreferrer"
                                 >MIT License</a
                             >
                             <a href="/terms/">Terms</a>

--- a/website/privacy/index.html
+++ b/website/privacy/index.html
@@ -106,7 +106,7 @@
                             <a
                                 href="https://github.com/Speculative-Dynamics/nod"
                                 target="_blank"
-                                rel="noopener"
+                                rel="noopener noreferrer"
                                 >github.com/Speculative-Dynamics/nod</a
                             >.
                         </p>
@@ -280,7 +280,7 @@
                         <a
                             href="https://github.com/Speculative-Dynamics/nod"
                             target="_blank"
-                            rel="noopener"
+                            rel="noopener noreferrer"
                             >github.com/Speculative-Dynamics/nod</a
                         >
                     </p>
@@ -305,7 +305,7 @@
                             <a
                                 href="https://github.com/Speculative-Dynamics/nod"
                                 target="_blank"
-                                rel="noopener"
+                                rel="noopener noreferrer"
                                 >GitHub</a
                             >
                             <a href="/terms/">Terms</a>

--- a/website/styles.css
+++ b/website/styles.css
@@ -517,10 +517,18 @@ button {
         transform 0.25s var(--ease-out-soft),
         background 0.25s;
 }
+.appstore-btn--disabled {
+    cursor: default;
+}
 .appstore-btn:hover {
     transform: translateY(-2px);
     background: #ffffff;
     box-shadow: 0 10px 24px -8px rgba(255, 255, 255, 0.25);
+}
+.appstore-btn--disabled:hover {
+    transform: none;
+    background: var(--ink);
+    box-shadow: none;
 }
 .appstore-btn__text {
     display: flex;

--- a/website/terms/index.html
+++ b/website/terms/index.html
@@ -112,7 +112,7 @@
                         <a
                             href="https://github.com/Speculative-Dynamics/nod/blob/main/LICENSE"
                             target="_blank"
-                            rel="noopener"
+                            rel="noopener noreferrer"
                             >github.com/Speculative-Dynamics/nod/blob/main/LICENSE</a
                         >. You are free to read, modify, redistribute, and build
                         the app from source under those terms.
@@ -268,7 +268,7 @@
                             <a
                                 href="https://github.com/Speculative-Dynamics/nod"
                                 target="_blank"
-                                rel="noopener"
+                                rel="noopener noreferrer"
                                 >GitHub</a
                             >
                             <a href="/terms/">Terms</a>


### PR DESCRIPTION
## Summary

- Replaces the placeholder App Store URL with a truthful coming-soon state across README and website copy.
- Removes the invalid structured-data download URL until the listing exists.
- Adds noreferrer to external website links and refreshes website deployment notes.
- Keeps the sidebar feedback row tint aligned with nearby action rows.

## Validation

- xcodebuild -project ios/Nod.xcodeproj -scheme Nod -destination generic/platform=iOS -derivedDataPath /tmp/nod-derived build
- xcodebuild -project ios/Nod.xcodeproj -scheme Nod -configuration Release -destination generic/platform=iOS -derivedDataPath /tmp/nod-derived-release build
- node --check website/script.js
- JSON, plist, LD+JSON, sitemap, external-link, YAML, and git diff whitespace checks
