### PR TITLE
Revert premature version bump in project.yml

### DIFF
--- a/ios/project.yml
+++ b/ios/project.yml
@@ -97,10 +97,14 @@ targets:
         # Marketing version: shown to users in App Store + Settings.
         # Bump on every public release. 1.0.0 shipped to the App Store on
         # 2026-04-27 (apps.apple.com/in/app/just-nod/id6762388689).
-        MARKETING_VERSION: "1.0.1"
+        # Bump to 1.0.1 (or higher) ONLY when shipping a user-visible
+        # change — keep this in sync with what's actually live.
+        MARKETING_VERSION: "1.0.0"
         # Build number: must increase monotonically across every TestFlight
         # / App Store upload (Apple rejects re-uploads at the same number).
-        CURRENT_PROJECT_VERSION: "23"
+        # Bump to 23 ONLY when uploading a new binary — until then this
+        # matches what's currently in App Store Connect (build 22).
+        CURRENT_PROJECT_VERSION: "22"
         GENERATE_INFOPLIST_FILE: NO
     dependencies:
       - package: GRDB


### PR DESCRIPTION
## Summary

#24 bumped `MARKETING_VERSION` to `1.0.1` and `CURRENT_PROJECT_VERSION` to `23` as "post-launch housekeeping" — but that PR didn't change anything that ships in the app binary (just website HTML, README, and App Store metadata docs). Bumping without a corresponding binary upload puts `project.yml` out of sync with what's actually live (1.0.0 / build 22) and wastes a version slot for nothing.

Restoring both to `1.0.0` / `22` to match what's in App Store Connect, and adding comments next to each so future bumps happen at the right moment:

- `MARKETING_VERSION`: bump only when shipping a user-visible change
- `CURRENT_PROJECT_VERSION`: bump only when uploading a new binary

## Test plan

- [ ] `cd ios && xcodegen` produces a pbxproj with `MARKETING_VERSION = 1.0.0` and `CURRENT_PROJECT_VERSION = 22`
- [ ] Confirm matches the live App Store build

🤖 Generated with [Claude Code](https://claude.com/claude-code)