### PR TITLE
Cache-bust og:image so social previews re-fetch

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -48,7 +48,7 @@
         />
         <meta
             property="og:image"
-            content="https://usenod.app/assets/og-image.jpg"
+            content="https://usenod.app/assets/og-image.jpg?v=launch"
         />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
@@ -69,7 +69,7 @@
         />
         <meta
             name="twitter:image"
-            content="https://usenod.app/assets/og-image.jpg"
+            content="https://usenod.app/assets/og-image.jpg?v=launch"
         />
         <meta
             name="twitter:image:alt"


### PR DESCRIPTION
## Summary

Twitter (and likely LinkedIn / iMessage / Discord) had a stale version of `website/assets/og-image.jpg` cached against the unversioned URL. The file has been replaced twice in the repo (most recently in `ad53ec8` "storytelling redesign"), but social previews still pulled an older cached version.

Appending `?v=launch` to `og:image` and `twitter:image` so platforms treat it as a new resource and re-fetch. Same physical file on disk, new URL key for the social bots.

## Test plan

- [ ] After merge + Pages deploy, run `https://usenod.app` through <https://www.linkedin.com/post-inspector/> and confirm it pulls the current watercolor hero
- [ ] For the existing X post: easiest fix is delete + re-share (either with attached image, or with `?ref=launch` query string to force X to re-crawl the page meta tags too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)