### PR TITLE
Fix mobile hero misalignment + add above-the-fold App Store CTA

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -115,6 +115,29 @@
             media="(max-aspect-ratio: 1/1)"
         />
 
+        <!-- Pick the right hero source + poster BEFORE the <video> element
+             is parsed, so the browser loads the correct asset on the
+             critical path. Eliminates the cold-load misalignment that
+             happened with <source media> + delayed JS poster swap:
+             the desktop poster (16:9) was rendering inside a portrait
+             container with object-fit:cover, cropping the boy + tree out
+             of frame until the mobile poster finally swapped in. -->
+        <script>
+            (function () {
+                var isMobile = window.matchMedia(
+                    "(max-aspect-ratio: 1/1)"
+                ).matches;
+                window.__heroAssets = {
+                    src: isMobile
+                        ? "/assets/hero/mobile.mp4"
+                        : "/assets/hero/desktop.mp4",
+                    poster: isMobile
+                        ? "/assets/hero/mobile.png"
+                        : "/assets/hero/desktop.png",
+                };
+            })();
+        </script>
+
         <!-- Fonts -->
         <link
             href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..600;1,9..144,300..500&family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
@@ -192,6 +215,15 @@
             <!-- Video layer: clip-path shrinks it from fullscreen into the
                  phone screen area. Depth layer 1. -->
             <div class="hero__video-wrap">
+                <!--
+                  Source + poster are set by the inline script below, which
+                  pulls from window.__heroAssets (initialized in <head>
+                  before this element parses). This avoids the <source media>
+                  selection race that caused first-paint misalignment on
+                  mobile cold loads. No-JS fallback: the static
+                  background-image on .hero (see styles.css) keeps the page
+                  visually intact.
+                -->
                 <video
                     class="hero__video"
                     autoplay
@@ -199,15 +231,16 @@
                     loop
                     playsinline
                     preload="metadata"
-                    poster="/assets/hero/desktop.png"
-                >
-                    <source
-                        src="/assets/hero/mobile.mp4"
-                        type="video/mp4"
-                        media="(max-aspect-ratio: 1/1)"
-                    />
-                    <source src="/assets/hero/desktop.mp4" type="video/mp4" />
-                </video>
+                ></video>
+                <script>
+                    (function () {
+                        var v = document.currentScript.previousElementSibling;
+                        var a = window.__heroAssets;
+                        if (!a) return;
+                        v.poster = a.poster;
+                        v.src = a.src;
+                    })();
+                </script>
                 <!-- Gradient wash for text legibility -->
                 <div class="hero__wash" aria-hidden="true"></div>
             </div>
@@ -326,6 +359,38 @@
                 <p class="hero__sub">
                     A small on-device listener. No servers. No accounts. No one
                     watching.
+                </p>
+                <!-- Hero CTA: above-the-fold App Store link so first-time
+                     visitors don't need to scroll to install. The .hero__cta
+                     class is already wired into the GSAP timeline (fades in
+                     after .hero__sub). -->
+                <div class="hero__cta">
+                    <a
+                        class="appstore-btn appstore-btn--hero"
+                        href="https://apps.apple.com/in/app/just-nod/id6762388689"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="Download Just Nod on the App Store"
+                    >
+                        <svg
+                            viewBox="0 0 40 40"
+                            width="34"
+                            height="34"
+                            aria-hidden="true"
+                        >
+                            <path
+                                fill="currentColor"
+                                d="M27.2 21.1c0-3.5 2.8-5.1 3-5.2-1.6-2.4-4.2-2.7-5.1-2.8-2.2-.2-4.2 1.3-5.3 1.3-1.1 0-2.8-1.3-4.6-1.2-2.4 0-4.6 1.4-5.8 3.5-2.5 4.3-.6 10.6 1.8 14.1 1.2 1.7 2.5 3.6 4.3 3.6 1.7-.1 2.4-1.1 4.5-1.1 2.1 0 2.7 1.1 4.6 1.1 1.9 0 3.1-1.7 4.3-3.5 1.4-2 1.9-3.9 1.9-4 0 0-3.6-1.4-3.6-5.6zM23.7 11c1-1.2 1.6-2.8 1.4-4.5-1.4.1-3.1 1-4.1 2.1-.9 1-1.7 2.7-1.5 4.3 1.5.2 3.1-.7 4.2-1.9z"
+                            />
+                        </svg>
+                        <span class="appstore-btn__text">
+                            <small>Download on the</small>
+                            <strong>App Store</strong>
+                        </span>
+                    </a>
+                </div>
+                <p class="hero__cta-meta">
+                    Free · Open source · Requires iPhone with Apple Intelligence (iOS 26+)
                 </p>
             </div>
 

--- a/website/script.js
+++ b/website/script.js
@@ -11,29 +11,18 @@
   ).matches;
 
   /* ------------------------------------------------------------------
-   * 0. Hero video poster-swap (mobile vs desktop)
-   *    Runs synchronously before video starts so the right still is
-   *    showing from the first frame.
+   * 0. Hero asset selection (poster + source) is now done INLINE in <head>
+   *    via window.__heroAssets, BEFORE the <video> element parses. See
+   *    index.html. That's the only correct moment to decide which mp4 +
+   *    still to use, because the previous deferred poster-swap pattern
+   *    raced with the browser's <source media> selection and caused a
+   *    visible mis-crop on cold mobile loads (desktop poster rendered
+   *    inside a portrait container with object-fit:cover, cropping the
+   *    boy + tree out of frame until the script swap landed).
+   *
+   *    Leaving this comment as a breadcrumb so future-us doesn't
+   *    re-introduce a deferred swap here.
    * ------------------------------------------------------------------ */
-  (() => {
-    const video = document.querySelector(".hero__video");
-    if (!video) return;
-    const mql = window.matchMedia("(max-aspect-ratio: 1/1)");
-    const sync = () => {
-      const poster = mql.matches
-        ? "/assets/hero/mobile.png"
-        : "/assets/hero/desktop.png";
-      if (video.getAttribute("poster") !== poster) {
-        video.setAttribute("poster", poster);
-      }
-    };
-    sync();
-    (mql.addEventListener ? mql.addEventListener : mql.addListener).call(
-      mql,
-      "change",
-      sync
-    );
-  })();
 
   /* ------------------------------------------------------------------
    * 1. Ensure hero video autoplays on iOS Safari quirks.

--- a/website/styles.css
+++ b/website/styles.css
@@ -228,6 +228,20 @@ button {
     padding: 6rem var(--gutter) clamp(4rem, 8vw, 7rem);
     overflow: hidden;
     isolation: isolate;
+    /* Static hero painting as the always-on fallback. The <video> overlays
+       this when JS + autoplay succeed; if the video is slow to load, blocked,
+       or the user has reduced-motion preference, the painting is what they
+       see. desktop.png (16:9) by default; the mobile-aspect query below
+       swaps to mobile.png (9:16) so the boy + tree stay in frame. */
+    background-image: url("/assets/hero/desktop.png");
+    background-size: cover;
+    background-position: center;
+}
+
+@media (max-aspect-ratio: 1/1) {
+    .hero {
+        background-image: url("/assets/hero/mobile.png");
+    }
 }
 
 .hero__video-wrap {
@@ -310,6 +324,29 @@ button {
     gap: 0.8rem;
     flex-wrap: wrap;
     justify-content: flex-end;
+}
+
+/* Above-the-fold App Store CTA in the hero. The base .appstore-btn lives
+   on the dark download-section card; the hero variant uses the same
+   white-on-dark visual but adds a subtle glow so it pops against the
+   moving twilight backdrop. */
+.appstore-btn--hero {
+    box-shadow: 0 14px 38px -16px rgba(255, 245, 230, 0.35);
+}
+.appstore-btn--hero:hover {
+    box-shadow: 0 18px 42px -14px rgba(255, 245, 230, 0.45);
+}
+
+/* Small line under the hero CTA explaining what's free and the device
+   requirements. Mirrors the meta line under the Download section card. */
+.hero__cta-meta {
+    margin: 1rem 0 0 auto;
+    max-width: 38ch;
+    font-size: 0.85rem;
+    line-height: 1.45;
+    color: var(--ink-soft);
+    text-align: right;
+    text-shadow: 0 2px 16px rgba(14, 12, 10, 0.7);
 }
 
 /* scroll indicator — moved to left so it doesn't collide with the right-aligned text */
@@ -618,19 +655,12 @@ button {
     html {
         scroll-behavior: auto;
     }
+    /* Hide the video — the static painting set as background-image on .hero
+       (always-on fallback in the base .hero rule above) is what these users
+       see. The duplicated background-image declarations that used to live
+       here are no longer needed. */
     .hero__video {
         display: none;
-    }
-    .hero {
-        background-image: url("/assets/hero/desktop.png");
-        background-size: cover;
-        background-position: center;
-    }
-}
-
-@media (prefers-reduced-motion: reduce) and (max-aspect-ratio: 1/1) {
-    .hero {
-        background-image: url("/assets/hero/mobile.png");
     }
 }
 
@@ -664,8 +694,14 @@ button {
         align-items: stretch;
         justify-content: flex-start;
     }
-    .hero__cta .btn {
+    .hero__cta .btn,
+    .hero__cta .appstore-btn {
         justify-content: center;
+    }
+    .hero__cta-meta {
+        margin: 1rem 0 0 0;
+        max-width: 100%;
+        text-align: left;
     }
 
     .footer__row {


### PR DESCRIPTION
## Summary

Two related changes shipped together — both touch the hero.

### Fix 1: mobile hero video misaligned on cold load, fine after reload

Three contributing root causes, all fixed:

1. **`<source media>` selection is one-shot at parse time and races with stylesheet/JS loading.** On cold mobile loads, the browser would sometimes start fetching the wrong source before viewport conditions stabilised. **Fix:** drop `<source>` children. Pick the asset URL in an inline `<head>` script (`window.__heroAssets`) BEFORE the `<video>` parses, then set `v.src` in an inline script immediately after. Deterministic, no race.

2. **Poster was hardcoded to `desktop.png` in HTML, then swapped via deferred JS.** Guaranteed flash of wrong-poster on every cold mobile load — desktop's 16:9 painting rendered inside a portrait container with `object-fit:cover` cropped the boy + tree out of frame. **Fix:** poster is now set in the same inline script as src, before first paint. Old swap block in `script.js` removed.

3. **No no-JS / pre-load fallback.** Hero was empty until JS ran. **Fix:** static painting promoted to always-on `background-image` on `.hero` (was previously only under `prefers-reduced-motion`). Video overlays it; mobile-aspect media query swaps to `mobile.png`.

`mobile.png` is 604×1080 (~9:16), `desktop.png` is 1920×1080 (16:9) — verified with `sips`. The crops produce completely different framings, which is why the swap matters.

### Fix 2: above-the-fold App Store CTA in the hero

Visitors landing on usenod.app from the launch posts had to scroll through 7+ pinned chapters to find the install link — most won't. Added a prominent App Store badge inside `.hero__content` between `.hero__sub` and the chapter list. Reuses the existing `.appstore-btn` markup with a new `--hero` modifier for a subtle warm glow against the twilight backdrop, and a `.hero__cta-meta` line below ("Free · Open source · Requires iPhone with Apple Intelligence (iOS 26+)").

The `.hero__cta` class was already wired into the GSAP fade-in timeline, so the button automatically inherits the title/subtitle staggered entrance — no JS changes needed.

## Test plan

- [ ] Open https://usenod.app on mobile cold (private window) → hero painting renders correctly framed (boy + tree in view) from first paint, no mid-render shuffle
- [ ] Same on desktop → hero renders cinematic landscape, video starts playing
- [ ] App Store CTA visible above the fold on both mobile and desktop, click goes to apps.apple.com/in/app/just-nod/...
- [ ] Reduced-motion still works (video hidden, painting shown)
- [ ] No-JS still works (background painting visible, just no video)

🤖 Generated with [Claude Code](https://claude.com/claude-code)