### PR TITLE
Declutter hero — three subtraction cuts

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -357,8 +357,7 @@
                     need to be <em>heard.</em>
                 </h1>
                 <p class="hero__sub">
-                    A small on-device listener. No servers. No accounts. No one
-                    watching.
+                    A small on-device listener. No one watching.
                 </p>
                 <!-- Hero CTA: above-the-fold App Store link so first-time
                      visitors don't need to scroll to install. The .hero__cta
@@ -389,9 +388,6 @@
                         </span>
                     </a>
                 </div>
-                <p class="hero__cta-meta">
-                    Free · Open source · Requires iPhone with Apple Intelligence (iOS 26+)
-                </p>
             </div>
 
             <!-- Chapters: 7 stacked text blocks that cross-fade as the

--- a/website/styles.css
+++ b/website/styles.css
@@ -326,28 +326,10 @@ button {
     justify-content: flex-end;
 }
 
-/* Above-the-fold App Store CTA in the hero. The base .appstore-btn lives
-   on the dark download-section card; the hero variant uses the same
-   white-on-dark visual but adds a subtle glow so it pops against the
-   moving twilight backdrop. */
-.appstore-btn--hero {
-    box-shadow: 0 14px 38px -16px rgba(255, 245, 230, 0.35);
-}
-.appstore-btn--hero:hover {
-    box-shadow: 0 18px 42px -14px rgba(255, 245, 230, 0.45);
-}
-
-/* Small line under the hero CTA explaining what's free and the device
-   requirements. Mirrors the meta line under the Download section card. */
-.hero__cta-meta {
-    margin: 1rem 0 0 auto;
-    max-width: 38ch;
-    font-size: 0.85rem;
-    line-height: 1.45;
-    color: var(--ink-soft);
-    text-align: right;
-    text-shadow: 0 2px 16px rgba(14, 12, 10, 0.7);
-}
+/* Above-the-fold App Store CTA in the hero. The base .appstore-btn already
+   has white-on-dark contrast that reads cleanly on the twilight painting.
+   No extra glow — the painting + button is the whole composition; decorative
+   shadows around the CTA dilute it. */
 
 /* scroll indicator — moved to left so it doesn't collide with the right-aligned text */
 .hero__scroll {
@@ -697,11 +679,6 @@ button {
     .hero__cta .btn,
     .hero__cta .appstore-btn {
         justify-content: center;
-    }
-    .hero__cta-meta {
-        margin: 1rem 0 0 0;
-        max-width: 100%;
-        text-align: left;
     }
 
     .footer__row {


### PR DESCRIPTION
## Summary

User feedback on the hero after shipping the App Store CTA: **"too cluttered."**

Looking at the screenshot, the right side had **4 stacked elements** (subtitle, button with glow, "Free · Open source · Requires iPhone..." meta line) all competing with the headline AND the painting for attention. The hero was doing too many jobs at once.

Three subtraction cuts, applying the principle: *"If deleting 30% of the copy improves it, keep deleting."*

| Cut | Why |
|---|---|
| Removed `.hero__cta-meta` line ("Free · Open source · Requires iPhone with Apple Intelligence (iOS 26+)") | 75 chars of secondary info at the visual climax. App Store listing already conveys all of it. Over-explanation erodes trust. |
| Shortened `.hero__sub` from 4 statements to 2 | Original: "A small on-device listener. No servers. No accounts. No one watching." → New: "A small on-device listener. No one watching." Same point, half the weight. |
| Dropped `.appstore-btn--hero` box-shadow glow | White button on twilight painting has plenty of contrast. Decorative glow was diluting the CTA, not helping it. |

**Net effect:** right-side cluster goes from 4 elements to 2 (subtitle, button). The painting breathes. The headline dominates as intended. The CTA still lands above the fold but no longer fights the composition.

## Test plan

- [ ] After deploy, open https://usenod.app on desktop → hero should feel quieter, painting visible behind less text noise
- [ ] App Store CTA still visible above the fold and clickable
- [ ] Mobile view → no orphan styles, layout still stacks cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)